### PR TITLE
Fill invite topic method

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+  semi: false,
+  singleQuote: true,
+  trailingComma: "es5",
+  arrowParens: "always",
+  printWidth: 80,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@types/yargs": "^17.0.13",
         "eslint": "^8.27.0",
         "prettier": "^2.7.1",
-        "typescript": "^4.9.3"
+        "typescript": "^4.9.5"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -2204,9 +2204,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
-      "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -3877,9 +3877,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
-      "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true
     },
     "undici": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@xmtp/proto": "^3.8.0",
-        "@xmtp/xmtp-js": "^7.1.2",
+        "@xmtp/proto": "3.24.0-beta.2",
+        "@xmtp/xmtp-js": "8.0.0-beta.19",
         "any-date-parser": "^1.5.3",
         "ethers": "^5.7.2",
         "yargs": "^17.6.2"
@@ -753,6 +753,17 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.0.tgz",
+      "integrity": "sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
     "node_modules/@noble/secp256k1": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.0.tgz",
@@ -853,6 +864,44 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
+    "node_modules/@spruceid/siwe-parser": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@spruceid/siwe-parser/-/siwe-parser-2.0.2.tgz",
+      "integrity": "sha512-9WuA0ios2537cWYu39MMeH0O2KdrMKgKlOBUTWRTXQjCYu5B+mHCA0JkCbFaJ/0EjxoVIcYCXIW/DoPEpw+PqA==",
+      "dependencies": {
+        "@noble/hashes": "^1.1.2",
+        "apg-js": "^4.1.1",
+        "uri-js": "^4.4.1",
+        "valid-url": "^1.0.9"
+      }
+    },
+    "node_modules/@stablelib/binary": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/binary/-/binary-1.0.1.tgz",
+      "integrity": "sha512-ClJWvmL6UBM/wjkvv/7m5VP3GMr9t0osr4yVgLZsLCOz4hGN9gIAFEqnJ0TsSMAN+n840nf2cHZnA5/KFqHC7Q==",
+      "dependencies": {
+        "@stablelib/int": "^1.0.1"
+      }
+    },
+    "node_modules/@stablelib/int": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/int/-/int-1.0.1.tgz",
+      "integrity": "sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w=="
+    },
+    "node_modules/@stablelib/random": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@stablelib/random/-/random-1.0.2.tgz",
+      "integrity": "sha512-rIsE83Xpb7clHPVRlBj8qNe5L8ISQOzjghYQm/dZ7VaM2KHYwMW5adjQjrzTZCchFnNCNhkwtnOBa9HTMJCI8w==",
+      "dependencies": {
+        "@stablelib/binary": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "node_modules/@stablelib/wipe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.1.tgz",
+      "integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg=="
+    },
     "node_modules/@stardazed/streams-polyfill": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@stardazed/streams-polyfill/-/streams-polyfill-2.4.0.tgz",
@@ -879,25 +928,29 @@
       "dev": true
     },
     "node_modules/@xmtp/proto": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.8.0.tgz",
-      "integrity": "sha512-xrkQtthZ+ugf4PiE9kL9B73F/VU/2gqnIkhNkgVqUX0/DWXF9ue/U8Usg9yUT1BhHPJeWt4gZ7KBR7gn4BbtEQ==",
+      "version": "3.24.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.24.0-beta.2.tgz",
+      "integrity": "sha512-Y15/WQ/3IGUFmrqUS6gSwc5X1m7D8B9OHYr+hpZ2862jf67DELz+SfgNWRbCUFsp5syXSjDg/6sRZ7GpSygKcw==",
       "dependencies": {
         "long": "^5.2.0",
         "protobufjs": "^7.0.0",
+        "rxjs": "^7.8.0",
         "undici": "^5.8.1"
       }
     },
     "node_modules/@xmtp/xmtp-js": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@xmtp/xmtp-js/-/xmtp-js-7.1.2.tgz",
-      "integrity": "sha512-4jaCOYaA+fFiM2h61809j+qvaYm7+ma189czLacVgZDwSeGKTwoW7XY10K76fwkVeH9uH3QnEZFTxax2jJ++RQ==",
+      "version": "8.0.0-beta.19",
+      "resolved": "https://registry.npmjs.org/@xmtp/xmtp-js/-/xmtp-js-8.0.0-beta.19.tgz",
+      "integrity": "sha512-jq+E3mjSwdZDT6xBneA5DOvs7m0dLcDK/yUoIMLHegGalx02EQd6RXwgPc0M90IAEU3qIzuhRr6wr4IM4jKijQ==",
       "dependencies": {
         "@noble/secp256k1": "^1.5.2",
         "@stardazed/streams-polyfill": "^2.4.0",
-        "@xmtp/proto": "^3.4.0",
+        "@xmtp/proto": "^3.24.0-beta.2",
+        "async-mutex": "^0.4.0",
+        "elliptic": "^6.5.4",
         "ethers": "^5.5.3",
-        "long": "^5.2.0"
+        "long": "^5.2.0",
+        "siwe": "^2.1.3"
       }
     },
     "node_modules/acorn": {
@@ -969,11 +1022,24 @@
       "resolved": "https://registry.npmjs.org/any-date-parser/-/any-date-parser-1.5.3.tgz",
       "integrity": "sha512-X4sMMSzNoGmZTrFzsNKygRF2J1rBQvHNEW6rArOEH+pWHsyM6SDiqVz8yAbuYE2qiVN7btluIjijMwVDMkDj+g=="
     },
+    "node_modules/apg-js": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/apg-js/-/apg-js-4.1.3.tgz",
+      "integrity": "sha512-XYyDcoBho8OpnWPRnedMwyL+76ovCtsESerHZEfY39dO4IrEqN97mdEYkOyHa0XTX5+3+U5FmpqPLttK0f7n6g=="
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
+    },
+    "node_modules/async-mutex": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.4.0.tgz",
+      "integrity": "sha512-eJFZ1YhRR8UN8eBLoNzcDPcy/jqjsg6I1AP+KvWQX80BqOSW1oJPJXDylPUEeMr2ZQvHgnQ//Lp6f3RQ1zI7HA==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -1897,7 +1963,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -1999,6 +2064,14 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
+      "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/scrypt-js": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
@@ -2023,6 +2096,20 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/siwe": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/siwe/-/siwe-2.1.3.tgz",
+      "integrity": "sha512-d20jADr6MI6oWPDHg9bE+CBsUYkQQ2g4+ayCQ3QapAuYeE/dvFWI/7lwOOV21EuqZMmyrLVOSezgVoq0HAn8yw==",
+      "dependencies": {
+        "@spruceid/siwe-parser": "^2.0.2",
+        "@stablelib/random": "^1.0.1",
+        "uri-js": "^4.4.1",
+        "valid-url": "^1.0.9"
+      },
+      "peerDependencies": {
+        "ethers": "^5.5.1"
       }
     },
     "node_modules/streamsearch": {
@@ -2087,6 +2174,11 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
+    "node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -2139,10 +2231,14 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/valid-url": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
+      "integrity": "sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA=="
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -2668,6 +2764,11 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
+    "@noble/hashes": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.0.tgz",
+      "integrity": "sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg=="
+    },
     "@noble/secp256k1": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.0.tgz",
@@ -2753,6 +2854,44 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
+    "@spruceid/siwe-parser": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@spruceid/siwe-parser/-/siwe-parser-2.0.2.tgz",
+      "integrity": "sha512-9WuA0ios2537cWYu39MMeH0O2KdrMKgKlOBUTWRTXQjCYu5B+mHCA0JkCbFaJ/0EjxoVIcYCXIW/DoPEpw+PqA==",
+      "requires": {
+        "@noble/hashes": "^1.1.2",
+        "apg-js": "^4.1.1",
+        "uri-js": "^4.4.1",
+        "valid-url": "^1.0.9"
+      }
+    },
+    "@stablelib/binary": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/binary/-/binary-1.0.1.tgz",
+      "integrity": "sha512-ClJWvmL6UBM/wjkvv/7m5VP3GMr9t0osr4yVgLZsLCOz4hGN9gIAFEqnJ0TsSMAN+n840nf2cHZnA5/KFqHC7Q==",
+      "requires": {
+        "@stablelib/int": "^1.0.1"
+      }
+    },
+    "@stablelib/int": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/int/-/int-1.0.1.tgz",
+      "integrity": "sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w=="
+    },
+    "@stablelib/random": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@stablelib/random/-/random-1.0.2.tgz",
+      "integrity": "sha512-rIsE83Xpb7clHPVRlBj8qNe5L8ISQOzjghYQm/dZ7VaM2KHYwMW5adjQjrzTZCchFnNCNhkwtnOBa9HTMJCI8w==",
+      "requires": {
+        "@stablelib/binary": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "@stablelib/wipe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.1.tgz",
+      "integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg=="
+    },
     "@stardazed/streams-polyfill": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@stardazed/streams-polyfill/-/streams-polyfill-2.4.0.tgz",
@@ -2779,25 +2918,29 @@
       "dev": true
     },
     "@xmtp/proto": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.8.0.tgz",
-      "integrity": "sha512-xrkQtthZ+ugf4PiE9kL9B73F/VU/2gqnIkhNkgVqUX0/DWXF9ue/U8Usg9yUT1BhHPJeWt4gZ7KBR7gn4BbtEQ==",
+      "version": "3.24.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@xmtp/proto/-/proto-3.24.0-beta.2.tgz",
+      "integrity": "sha512-Y15/WQ/3IGUFmrqUS6gSwc5X1m7D8B9OHYr+hpZ2862jf67DELz+SfgNWRbCUFsp5syXSjDg/6sRZ7GpSygKcw==",
       "requires": {
         "long": "^5.2.0",
         "protobufjs": "^7.0.0",
+        "rxjs": "^7.8.0",
         "undici": "^5.8.1"
       }
     },
     "@xmtp/xmtp-js": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@xmtp/xmtp-js/-/xmtp-js-7.1.2.tgz",
-      "integrity": "sha512-4jaCOYaA+fFiM2h61809j+qvaYm7+ma189czLacVgZDwSeGKTwoW7XY10K76fwkVeH9uH3QnEZFTxax2jJ++RQ==",
+      "version": "8.0.0-beta.19",
+      "resolved": "https://registry.npmjs.org/@xmtp/xmtp-js/-/xmtp-js-8.0.0-beta.19.tgz",
+      "integrity": "sha512-jq+E3mjSwdZDT6xBneA5DOvs7m0dLcDK/yUoIMLHegGalx02EQd6RXwgPc0M90IAEU3qIzuhRr6wr4IM4jKijQ==",
       "requires": {
         "@noble/secp256k1": "^1.5.2",
         "@stardazed/streams-polyfill": "^2.4.0",
-        "@xmtp/proto": "^3.4.0",
+        "@xmtp/proto": "^3.24.0-beta.2",
+        "async-mutex": "^0.4.0",
+        "elliptic": "^6.5.4",
         "ethers": "^5.5.3",
-        "long": "^5.2.0"
+        "long": "^5.2.0",
+        "siwe": "^2.1.3"
       }
     },
     "acorn": {
@@ -2848,11 +2991,24 @@
       "resolved": "https://registry.npmjs.org/any-date-parser/-/any-date-parser-1.5.3.tgz",
       "integrity": "sha512-X4sMMSzNoGmZTrFzsNKygRF2J1rBQvHNEW6rArOEH+pWHsyM6SDiqVz8yAbuYE2qiVN7btluIjijMwVDMkDj+g=="
     },
+    "apg-js": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/apg-js/-/apg-js-4.1.3.tgz",
+      "integrity": "sha512-XYyDcoBho8OpnWPRnedMwyL+76ovCtsESerHZEfY39dO4IrEqN97mdEYkOyHa0XTX5+3+U5FmpqPLttK0f7n6g=="
+    },
     "argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
+    },
+    "async-mutex": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.4.0.tgz",
+      "integrity": "sha512-eJFZ1YhRR8UN8eBLoNzcDPcy/jqjsg6I1AP+KvWQX80BqOSW1oJPJXDylPUEeMr2ZQvHgnQ//Lp6f3RQ1zI7HA==",
+      "requires": {
+        "tslib": "^2.4.0"
+      }
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -3568,8 +3724,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -3618,6 +3773,14 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "rxjs": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
+      "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
+      "requires": {
+        "tslib": "^2.1.0"
+      }
+    },
     "scrypt-js": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
@@ -3637,6 +3800,17 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
+    },
+    "siwe": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/siwe/-/siwe-2.1.3.tgz",
+      "integrity": "sha512-d20jADr6MI6oWPDHg9bE+CBsUYkQQ2g4+ayCQ3QapAuYeE/dvFWI/7lwOOV21EuqZMmyrLVOSezgVoq0HAn8yw==",
+      "requires": {
+        "@spruceid/siwe-parser": "^2.0.2",
+        "@stablelib/random": "^1.0.1",
+        "uri-js": "^4.4.1",
+        "valid-url": "^1.0.9"
+      }
     },
     "streamsearch": {
       "version": "1.1.0",
@@ -3682,6 +3856,11 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
+    "tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    },
     "type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -3715,10 +3894,14 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "valid-url": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
+      "integrity": "sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA=="
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@types/yargs": "^17.0.13",
     "eslint": "^8.27.0",
     "prettier": "^2.7.1",
-    "typescript": "^4.9.3"
+    "typescript": "^4.9.5"
   },
   "dependencies": {
     "@xmtp/proto": "3.24.0-beta.2",

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "typescript": "^4.9.3"
   },
   "dependencies": {
-    "@xmtp/proto": "^3.8.0",
-    "@xmtp/xmtp-js": "^7.1.2",
+    "@xmtp/proto": "3.24.0-beta.2",
+    "@xmtp/xmtp-js": "8.0.0-beta.19",
     "any-date-parser": "^1.5.3",
     "ethers": "^5.7.2",
     "yargs": "^17.6.2"

--- a/src/contacts.ts
+++ b/src/contacts.ts
@@ -1,8 +1,8 @@
 import { SignedPublicKeyBundle, PublicKeyBundle } from '@xmtp/xmtp-js'
-// @ts-ignore
 import {
   buildUserContactTopic,
   nsToDate,
+  // @ts-ignore
 } from '@xmtp/xmtp-js/dist/cjs/src/utils'
 // @ts-ignore
 import { decodeContactBundle } from '@xmtp/xmtp-js/dist/cjs/src/ContactBundle'
@@ -21,7 +21,7 @@ type Contact = {
 export default async function contacts(argv: any) {
   const { client, cmd, address, long } = argv
   const contacts = await client.listEnvelopes(
-    [buildUserContactTopic(address)],
+    buildUserContactTopic(address),
     async (env: any) => {
       if (!env.message) {
         throw new Error('No message')

--- a/src/contacts.ts
+++ b/src/contacts.ts
@@ -1,6 +1,9 @@
 import { SignedPublicKeyBundle, PublicKeyBundle } from '@xmtp/xmtp-js'
 // @ts-ignore
-import { buildUserContactTopic, nsToDate } from '@xmtp/xmtp-js/dist/cjs/src/utils'
+import {
+  buildUserContactTopic,
+  nsToDate,
+} from '@xmtp/xmtp-js/dist/cjs/src/utils'
 // @ts-ignore
 import { decodeContactBundle } from '@xmtp/xmtp-js/dist/cjs/src/ContactBundle'
 // @ts-ignore
@@ -11,54 +14,61 @@ import { toListOptions } from './utils'
 const { b64Decode } = fetcher
 
 type Contact = {
-  timestamp: Date,
+  timestamp: Date
   contact: PublicKeyBundle | SignedPublicKeyBundle
 }
 
 export default async function contacts(argv: any) {
-    const {client, cmd, address, long} = argv
-    const contacts = await client.listEnvelopes(
-      [buildUserContactTopic(address)],
-      async (env: any) => {
-        if (!env.message) {
-          throw new Error('No message')
-        }
-        return {
-          timestamp: nsToDate(Long.fromString(env.timestampNs as string)),
-          contact: decodeContactBundle(
-            b64Decode(env.message as unknown as string)
-          ),
-        }
-      },
-      toListOptions(argv)
-    )
-    switch(cmd){
-      case 'list': await list(contacts, !long); break;
-      case 'check': await check(contacts); break;
-      default: console.log(`invalid command ${cmd}`)
+  const { client, cmd, address, long } = argv
+  const contacts = await client.listEnvelopes(
+    [buildUserContactTopic(address)],
+    async (env: any) => {
+      if (!env.message) {
+        throw new Error('No message')
       }
-    }
-
-  async function list(contacts: Contact[], shouldTruncate = true) {
-    let rows = []
-    for (const { timestamp, contact } of contacts) {
-      const type =
-        contact instanceof PublicKeyBundle
-          ? 'V1'
-          : contact instanceof SignedPublicKeyBundle
-          ? 'V2'
-          : typeof contact
-      const identityKey = bytesToHex(contact.identityKey.secp256k1Uncompressed.bytes)
-      const preKey = bytesToHex(contact.preKey.secp256k1Uncompressed.bytes)
-      rows.push({
-        date: timestamp,
-        type: type,
-        identityKey: truncateHex(identityKey, shouldTruncate),
-        preKey: truncateHex(preKey, shouldTruncate)
-      })
-    }
-    console.table(rows)
+      return {
+        timestamp: nsToDate(Long.fromString(env.timestampNs as string)),
+        contact: decodeContactBundle(
+          b64Decode(env.message as unknown as string)
+        ),
+      }
+    },
+    toListOptions(argv)
+  )
+  switch (cmd) {
+    case 'list':
+      await list(contacts, !long)
+      break
+    case 'check':
+      await check(contacts)
+      break
+    default:
+      console.log(`invalid command ${cmd}`)
   }
+}
+
+async function list(contacts: Contact[], shouldTruncate = true) {
+  let rows = []
+  for (const { timestamp, contact } of contacts) {
+    const type =
+      contact instanceof PublicKeyBundle
+        ? 'V1'
+        : contact instanceof SignedPublicKeyBundle
+        ? 'V2'
+        : typeof contact
+    const identityKey = bytesToHex(
+      contact.identityKey.secp256k1Uncompressed.bytes
+    )
+    const preKey = bytesToHex(contact.preKey.secp256k1Uncompressed.bytes)
+    rows.push({
+      date: timestamp,
+      type: type,
+      identityKey: truncateHex(identityKey, shouldTruncate),
+      preKey: truncateHex(preKey, shouldTruncate),
+    })
+  }
+  console.table(rows)
+}
 
 async function check(contacts: Contact[]) {
   let lastContact: Contact | null = null
@@ -67,10 +77,7 @@ async function check(contacts: Contact[]) {
   for (const contact of contacts) {
     numContacts++
     if (lastContact && !equal(lastContact, contact)) {
-      console.log(
-        'Contact changed',
-        contact.timestamp
-      )
+      console.log('Contact changed', contact.timestamp)
       numMismatched++
     }
     lastContact = contact
@@ -82,14 +89,20 @@ async function check(contacts: Contact[]) {
 
 function equal(a: Contact, b: Contact): boolean {
   return a.contact instanceof PublicKeyBundle
-  ? b.contact instanceof PublicKeyBundle ?
-      a.contact.equals(b.contact):false
-  : b.contact instanceof SignedPublicKeyBundle ?
-      a.contact.equals(b.contact): false
+    ? b.contact instanceof PublicKeyBundle
+      ? a.contact.equals(b.contact)
+      : false
+    : b.contact instanceof SignedPublicKeyBundle
+    ? a.contact.equals(b.contact)
+    : false
 }
 
 function truncateHex(hex: string, shouldTruncate = true): string {
-  if(!shouldTruncate) { return hex }
-  if(hex.length < 8) { return hex }
-  return `${hex.slice(0,4)}…${hex.slice(-4)}`
+  if (!shouldTruncate) {
+    return hex
+  }
+  if (hex.length < 8) {
+    return hex
+  }
+  return `${hex.slice(0, 4)}…${hex.slice(-4)}`
 }

--- a/src/fillConversationList.ts
+++ b/src/fillConversationList.ts
@@ -1,0 +1,21 @@
+import { Client } from '@xmtp/xmtp-js'
+import { randomWallet, resolveAddress } from './utils'
+
+export default async function fillInvites(argv: any) {
+  const { env, address: rawAddress, numInvites, numMessagesPerConvo } = argv
+  const address = await resolveAddress(rawAddress)
+  console.log(
+    `Sending ${numInvites} invites to ${address} and sending ${numMessagesPerConvo} messages per invite`
+  )
+
+  for (let i = 0; i < numInvites; i++) {
+    const client = await Client.create(randomWallet(), { env })
+    const convo = await client.conversations.newConversation(address, {
+      conversationId: `xmtp.org/test/${i}`,
+      metadata: {},
+    })
+    for (let j = 0; j < numMessagesPerConvo; j++) {
+      await convo.send(`gm ${j}`)
+    }
+  }
+}

--- a/src/fillConversationList.ts
+++ b/src/fillConversationList.ts
@@ -8,14 +8,16 @@ export default async function fillInvites(argv: any) {
     `Sending ${numInvites} invites to ${address} and sending ${numMessagesPerConvo} messages per invite`
   )
 
-  for (let i = 0; i < numInvites; i++) {
-    const client = await Client.create(randomWallet(), { env })
-    const convo = await client.conversations.newConversation(address, {
-      conversationId: `xmtp.org/test/${i}`,
-      metadata: {},
+  await Promise.all(
+    Array.from({ length: numInvites }, async (_, i) => {
+      const client = await Client.create(randomWallet(), { env })
+      const convo = await client.conversations.newConversation(address, {
+        conversationId: `xmtp.org/test/${i}`,
+        metadata: {},
+      })
+      for (let j = 0; j < numMessagesPerConvo; j++) {
+        await convo.send(`gm ${j}`)
+      }
     })
-    for (let j = 0; j < numMessagesPerConvo; j++) {
-      await convo.send(`gm ${j}`)
-    }
-  }
+  )
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,159 +1,159 @@
-import yargs, { number } from "yargs";
-import { hideBin } from "yargs/helpers";
-import { Client } from "@xmtp/xmtp-js";
+import yargs, { number } from 'yargs'
+import { hideBin } from 'yargs/helpers'
+import { Client } from '@xmtp/xmtp-js'
 import {
   loadWallet,
   saveRandomWallet,
   resolveAddress,
   WALLET_FILE_LOCATION,
   randomWallet,
-} from "./utils";
-import intros from "./intros";
-import contacts from "./contacts";
-import privateKeys from "./privateKeys";
-import invites from "./invites";
+} from './utils'
+import intros from './intros'
+import contacts from './contacts'
+import privateKeys from './privateKeys'
+import invites from './invites'
 
 yargs(hideBin(process.argv))
   .scriptName(`npm start`)
-  .command("init", "initialize wallet", {}, async (argv: any) => {
-    const { env } = argv;
-    saveRandomWallet();
-    const client = await Client.create(loadWallet(), { env });
+  .command('init', 'initialize wallet', {}, async (argv: any) => {
+    const { env } = argv
+    saveRandomWallet()
+    const client = await Client.create(loadWallet(), { env })
     console.log(
       `New wallet with address ${client.address} saved at ${WALLET_FILE_LOCATION}`
-    );
+    )
   })
   .command(
-    "intros [cmd] [address]",
-    "list/check introduction messages for the address",
+    'intros [cmd] [address]',
+    'list/check introduction messages for the address',
     {
-      cmd: { type: "string", choices: ["check", "list"], default: "list" },
-      address: { type: "string" },
+      cmd: { type: 'string', choices: ['check', 'list'], default: 'list' },
+      address: { type: 'string' },
     },
     async (argv: yargs.Arguments) => {
-      await intros(await resolve(argv));
+      await intros(await resolve(argv))
     }
   )
   .example(
-    "$0 intros list xmtp.eth",
-    "list all introduction messages for xmtp.eth"
+    '$0 intros list xmtp.eth',
+    'list all introduction messages for xmtp.eth'
   )
   .example(
-    "$0 -- -d -l10 intros list xmtp.eth",
-    "list last 10 introduction messages for xmtp.eth in descending order"
+    '$0 -- -d -l10 intros list xmtp.eth',
+    'list last 10 introduction messages for xmtp.eth in descending order'
   )
   .command(
-    "invites [cmd] [address]",
-    "list/check introductions for the address",
+    'invites [cmd] [address]',
+    'list/check introductions for the address',
     {
-      cmd: { type: "string", choices: ["check", "list"], default: "list" },
-      address: { type: "string" },
+      cmd: { type: 'string', choices: ['check', 'list'], default: 'list' },
+      address: { type: 'string' },
     },
     async (argv: any) => {
-      await invites(await resolve(argv));
+      await invites(await resolve(argv))
     }
   )
   .example(
-    "$0 -- --full invites list xmtp.eth",
-    "list all invitations for xmtp.eth, do not shorten addresses"
+    '$0 -- --full invites list xmtp.eth',
+    'list all invitations for xmtp.eth, do not shorten addresses'
   )
   .command(
-    "contacts [cmd] [address]",
-    "list/check published contacts for the address",
+    'contacts [cmd] [address]',
+    'list/check published contacts for the address',
     {
-      cmd: { type: "string", choices: ["check", "list"], default: "list" },
-      address: { type: "string" },
+      cmd: { type: 'string', choices: ['check', 'list'], default: 'list' },
+      address: { type: 'string' },
     },
     async (argv: any) => {
-      await contacts(await resolve(argv));
+      await contacts(await resolve(argv))
     }
   )
   .example(
-    "$0 -- -e=production contacts check xmtp.eth",
-    "check all contacts of xmtp.eth for anomalies on the production network"
+    '$0 -- -e=production contacts check xmtp.eth',
+    'check all contacts of xmtp.eth for anomalies on the production network'
   )
   .command(
-    "private [address]",
-    "list published private key bundles for the address",
+    'private [address]',
+    'list published private key bundles for the address',
     {
-      address: { type: "string" },
+      address: { type: 'string' },
     },
     async (argv: any) => {
-      await privateKeys(await resolve(argv));
+      await privateKeys(await resolve(argv))
     }
   )
-  .option("env", {
-    alias: "e",
-    type: "string",
-    default: "dev",
-    choices: ["local", "dev", "production"] as const,
-    description: "The XMTP environment to use",
+  .option('env', {
+    alias: 'e',
+    type: 'string',
+    default: 'dev',
+    choices: ['local', 'dev', 'production'] as const,
+    description: 'The XMTP environment to use',
   })
-  .option("address", {
-    alias: "a",
-    type: "string",
-    description: "wallet address to inspect",
+  .option('address', {
+    alias: 'a',
+    type: 'string',
+    description: 'wallet address to inspect',
   })
-  .option("full", {
-    alias: "f",
-    type: "boolean",
+  .option('full', {
+    alias: 'f',
+    type: 'boolean',
     default: false,
-    description: "do not shorten long output items",
+    description: 'do not shorten long output items',
   })
-  .option("start", {
-    alias: "s",
-    type: "string",
-    description: "restrict output to dates on or after this date",
+  .option('start', {
+    alias: 's',
+    type: 'string',
+    description: 'restrict output to dates on or after this date',
   })
-  .option("end", {
-    alias: "n",
-    type: "string",
-    description: "restrict output to dates before this date",
+  .option('end', {
+    alias: 'n',
+    type: 'string',
+    description: 'restrict output to dates before this date',
   })
-  .option("limit", {
-    alias: "l",
-    type: "number",
-    description: "restrict output to first <limit> entries",
+  .option('limit', {
+    alias: 'l',
+    type: 'number',
+    description: 'restrict output to first <limit> entries',
   })
-  .option("desc", {
-    alias: "d",
-    type: "boolean",
-    description: "sort output in descending order",
+  .option('desc', {
+    alias: 'd',
+    type: 'boolean',
+    description: 'sort output in descending order',
   })
   .command(
-    "fill-conversation-list [address] [numInvites] [numMessagesPerConvo]",
+    'fill-conversation-list [address] [numInvites] [numMessagesPerConvo]',
     `Fill the targeted address with the specified number of conversation invites.
     
     numInvites * numMessagesPerConvo should be < 499 to avoid rate limiting`,
     {
-      address: { type: "string" },
-      numInvites: { type: "number" },
-      numMessagesPerConvo: { type: "number", default: 0 },
+      address: { type: 'string' },
+      numInvites: { type: 'number' },
+      numMessagesPerConvo: { type: 'number', default: 0 },
     },
     async (argv: any) => {
-      const { env, address, numInvites, numMessagesPerConvo } = argv;
+      const { env, address, numInvites, numMessagesPerConvo } = argv
       for (let i = 0; i < numInvites; i++) {
-        const client = await Client.create(randomWallet(), { env });
+        const client = await Client.create(randomWallet(), { env })
         const convo = await client.conversations.newConversation(address, {
           conversationId: `xmtp.org/test/${i}`,
           metadata: {},
-        });
+        })
         for (let j = 0; j < numMessagesPerConvo; j++) {
-          await convo.send(`gm ${j}`);
+          await convo.send(`gm ${j}`)
         }
       }
     }
   )
   // all options can be passed in as env vars prefixed with XMTP_
-  .env("XMTP")
+  .env('XMTP')
   // log the network environment used
   .middleware((argv) => console.log(`XMTP environment: ${argv.env}`))
   .demandCommand(1)
-  .parse();
+  .parse()
 
 async function resolve(argv: any) {
-  const { env, address } = argv;
-  argv.client = await Client.create(loadWallet(), { env });
-  argv.address = await resolveAddress(address);
-  return argv;
+  const { env, address } = argv
+  argv.client = await Client.create(loadWallet(), { env })
+  argv.address = await resolveAddress(address)
+  return argv
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,123 +1,158 @@
-import yargs, { number } from 'yargs'
-import { hideBin } from 'yargs/helpers'
-import { Client } from '@xmtp/xmtp-js'
+import yargs, { number } from "yargs";
+import { hideBin } from "yargs/helpers";
+import { Client } from "@xmtp/xmtp-js";
 import {
   loadWallet,
   saveRandomWallet,
   resolveAddress,
   WALLET_FILE_LOCATION,
-} from './utils'
-import intros from './intros'
-import contacts from './contacts'
-import privateKeys from './privateKeys'
-import invites from './invites'
+} from "./utils";
+import intros from "./intros";
+import contacts from "./contacts";
+import privateKeys from "./privateKeys";
+import invites from "./invites";
 
 yargs(hideBin(process.argv))
   .scriptName(`npm start`)
-  .command('init', 'initialize wallet', {}, async (argv: any) => {
-    const { env } = argv
-    saveRandomWallet()
-    const client = await Client.create(loadWallet(), { env })
+  .command("init", "initialize wallet", {}, async (argv: any) => {
+    const { env } = argv;
+    saveRandomWallet();
+    const client = await Client.create(loadWallet(), { env });
     console.log(
-       `New wallet with address ${client.address} saved at ${WALLET_FILE_LOCATION}`
-    )
+      `New wallet with address ${client.address} saved at ${WALLET_FILE_LOCATION}`
+    );
   })
   .command(
-    'intros [cmd] [address]',
-    'list/check introduction messages for the address',
-    { 
-      cmd: { type: 'string', choices: ['check', 'list'], default: 'list'},
-      address: { type: 'string' },
+    "intros [cmd] [address]",
+    "list/check introduction messages for the address",
+    {
+      cmd: { type: "string", choices: ["check", "list"], default: "list" },
+      address: { type: "string" },
     },
     async (argv: yargs.Arguments) => {
-      await intros(await resolve(argv))
+      await intros(await resolve(argv));
     }
   )
-  .example('$0 intros list xmtp.eth', 'list all introduction messages for xmtp.eth')
-  .example('$0 -- -d -l10 intros list xmtp.eth', 'list last 10 introduction messages for xmtp.eth in descending order')
+  .example(
+    "$0 intros list xmtp.eth",
+    "list all introduction messages for xmtp.eth"
+  )
+  .example(
+    "$0 -- -d -l10 intros list xmtp.eth",
+    "list last 10 introduction messages for xmtp.eth in descending order"
+  )
   .command(
-    'invites [cmd] [address]',
-    'list/check introductions for the address',
-    { 
-      cmd: { type: 'string', choices: ['check', 'list'], default: 'list'},
-      address: { type: 'string' },
+    "invites [cmd] [address]",
+    "list/check introductions for the address",
+    {
+      cmd: { type: "string", choices: ["check", "list"], default: "list" },
+      address: { type: "string" },
     },
     async (argv: any) => {
-      await invites(await resolve(argv))
+      await invites(await resolve(argv));
     }
   )
-  .example('$0 -- --full invites list xmtp.eth', 'list all invitations for xmtp.eth, do not shorten addresses')
+  .example(
+    "$0 -- --full invites list xmtp.eth",
+    "list all invitations for xmtp.eth, do not shorten addresses"
+  )
   .command(
-    'contacts [cmd] [address]',
-    'list/check published contacts for the address',
-    { 
-      cmd: { type: 'string', choices: ['check', 'list'], default: 'list'},
-      address: { type: 'string' },
+    "contacts [cmd] [address]",
+    "list/check published contacts for the address",
+    {
+      cmd: { type: "string", choices: ["check", "list"], default: "list" },
+      address: { type: "string" },
     },
     async (argv: any) => {
-      await contacts(await resolve(argv))
+      await contacts(await resolve(argv));
     }
   )
-  .example('$0 -- -e=production contacts check xmtp.eth', 'check all contacts of xmtp.eth for anomalies on the production network')
+  .example(
+    "$0 -- -e=production contacts check xmtp.eth",
+    "check all contacts of xmtp.eth for anomalies on the production network"
+  )
   .command(
-    'private [address]',
-    'list published private key bundles for the address',
-    { 
-      address: { type: 'string' },
+    "private [address]",
+    "list published private key bundles for the address",
+    {
+      address: { type: "string" },
     },
     async (argv: any) => {
-      await privateKeys(await resolve(argv))
+      await privateKeys(await resolve(argv));
     }
   )
-  .option('env', {
-    alias: 'e',
-    type: 'string',
-    default: 'dev',
-    choices: ['local', 'dev', 'production'] as const,
-    description: 'The XMTP environment to use',
+  .option("env", {
+    alias: "e",
+    type: "string",
+    default: "dev",
+    choices: ["local", "dev", "production"] as const,
+    description: "The XMTP environment to use",
   })
-  .option('address', {
-    alias: 'a',
-    type: 'string',
-    description: 'wallet address to inspect'
+  .option("address", {
+    alias: "a",
+    type: "string",
+    description: "wallet address to inspect",
   })
-  .option('full', {
-    alias: 'f',
-    type: 'boolean',
+  .option("full", {
+    alias: "f",
+    type: "boolean",
     default: false,
-    description: 'do not shorten long output items'
+    description: "do not shorten long output items",
   })
-  .option('start', {
-    alias: 's',
-    type: 'string',
-    description: 'restrict output to dates on or after this date'
+  .option("start", {
+    alias: "s",
+    type: "string",
+    description: "restrict output to dates on or after this date",
   })
-  .option('end', {
-    alias: 'n',
-    type: 'string',
-    description: 'restrict output to dates before this date'
+  .option("end", {
+    alias: "n",
+    type: "string",
+    description: "restrict output to dates before this date",
   })
-  .option('limit', {
-    alias: 'l',
-    type: 'number',
-    description: 'restrict output to first <limit> entries'
+  .option("limit", {
+    alias: "l",
+    type: "number",
+    description: "restrict output to first <limit> entries",
   })
-  .option('desc', {
-    alias: 'd',
-    type: 'boolean',
-    description: 'sort output in descending order'
+  .option("desc", {
+    alias: "d",
+    type: "boolean",
+    description: "sort output in descending order",
   })
+  .command(
+    "fill-conversation-list [address] [numInvites] [numMessagesPerConvo]",
+    `Fill the targeted address with the specified number of conversation invites.
+    
+    numInvites * numMessagesPerConvo should be < 499 to avoid rate limiting`,
+    {
+      address: { type: "string" },
+      numInvites: { type: "number" },
+      numMessagesPerConvo: { type: "number", default: 0 },
+    },
+    async (argv: any) => {
+      const { env, address, numInvites, numMessagesPerConvo } = argv;
+      for (let i = 0; i < numInvites; i++) {
+        const client = await Client.create(randomWallet(), { env });
+        const convo = await client.conversations.newConversation(address, {
+          conversationId: `xmtp.org/test/${i}`,
+          metadata: {},
+        });
+        for (let j = 0; j < numMessagesPerConvo; j++) {
+          await convo.send(`gm ${j}`);
+        }
+      }
+    }
+  )
   // all options can be passed in as env vars prefixed with XMTP_
-  .env('XMTP')
+  .env("XMTP")
   // log the network environment used
-  .middleware(argv => console.log(`XMTP environment: ${argv.env}`))
+  .middleware((argv) => console.log(`XMTP environment: ${argv.env}`))
   .demandCommand(1)
-  .parse()
+  .parse();
 
 async function resolve(argv: any) {
-  const { env, address } = argv
-  argv.client = await Client.create(loadWallet(), { env })
-  argv.address = await resolveAddress(address)
-  return argv
+  const { env, address } = argv;
+  argv.client = await Client.create(loadWallet(), { env });
+  argv.address = await resolveAddress(address);
+  return argv;
 }
-

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import {
   saveRandomWallet,
   resolveAddress,
   WALLET_FILE_LOCATION,
+  randomWallet,
 } from "./utils";
 import intros from "./intros";
 import contacts from "./contacts";

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,7 +87,7 @@ yargs(hideBin(process.argv))
     'fill-conversation-list [address] [numInvites] [numMessagesPerConvo]',
     `Fill the targeted address with the specified number of conversation invites.
     
-    numInvites * numMessagesPerConvo should be < 499 to avoid rate limiting`,
+    (numInvites * 3) + (numInvites * numMessagesPerConvo) should be < 1000 to avoid rate limiting`,
     {
       address: { type: 'string' },
       numInvites: { type: 'number' },
@@ -96,6 +96,10 @@ yargs(hideBin(process.argv))
     async (argv) => {
       await fillConversationList(argv)
     }
+  )
+  .example(
+    '$0 -- fill-conversation-list xmtp.eth 10 1',
+    'Start 10 conversations with xmtp.eth and send one message per conversation'
   )
   .option('env', {
     alias: 'e',

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import intros from './intros'
 import contacts from './contacts'
 import privateKeys from './privateKeys'
 import invites from './invites'
+import fillConversationList from './fillConversationList'
 
 yargs(hideBin(process.argv))
   .scriptName(`npm start`)
@@ -82,6 +83,20 @@ yargs(hideBin(process.argv))
       await privateKeys(await resolve(argv))
     }
   )
+  .command(
+    'fill-conversation-list [address] [numInvites] [numMessagesPerConvo]',
+    `Fill the targeted address with the specified number of conversation invites.
+    
+    numInvites * numMessagesPerConvo should be < 499 to avoid rate limiting`,
+    {
+      address: { type: 'string' },
+      numInvites: { type: 'number' },
+      numMessagesPerConvo: { type: 'number', default: 0 },
+    },
+    async (argv) => {
+      await fillConversationList(argv)
+    }
+  )
   .option('env', {
     alias: 'e',
     type: 'string',
@@ -120,30 +135,6 @@ yargs(hideBin(process.argv))
     type: 'boolean',
     description: 'sort output in descending order',
   })
-  .command(
-    'fill-conversation-list [address] [numInvites] [numMessagesPerConvo]',
-    `Fill the targeted address with the specified number of conversation invites.
-    
-    numInvites * numMessagesPerConvo should be < 499 to avoid rate limiting`,
-    {
-      address: { type: 'string' },
-      numInvites: { type: 'number' },
-      numMessagesPerConvo: { type: 'number', default: 0 },
-    },
-    async (argv: any) => {
-      const { env, address, numInvites, numMessagesPerConvo } = argv
-      for (let i = 0; i < numInvites; i++) {
-        const client = await Client.create(randomWallet(), { env })
-        const convo = await client.conversations.newConversation(address, {
-          conversationId: `xmtp.org/test/${i}`,
-          metadata: {},
-        })
-        for (let j = 0; j < numMessagesPerConvo; j++) {
-          await convo.send(`gm ${j}`)
-        }
-      }
-    }
-  )
   // all options can be passed in as env vars prefixed with XMTP_
   .env('XMTP')
   // log the network environment used

--- a/src/intros.ts
+++ b/src/intros.ts
@@ -1,4 +1,9 @@
-import { SortDirection, PublicKey, PublicKeyBundle, SignedPublicKeyBundle } from '@xmtp/xmtp-js'
+import {
+  SortDirection,
+  PublicKey,
+  PublicKeyBundle,
+  SignedPublicKeyBundle,
+} from '@xmtp/xmtp-js'
 // @ts-ignore
 import { buildUserIntroTopic, nsToDate } from '@xmtp/xmtp-js/dist/cjs/src/utils'
 // @ts-ignore
@@ -9,69 +14,84 @@ import { toListOptions, truncateEthAddress } from './utils'
 const { b64Decode } = fetcher
 
 export default async function intros(argv: any) {
-  const {client, cmd, address, long} = argv
+  const { client, cmd, address, long } = argv
   let currentContact = await client.getUserContact(address)
   if (!currentContact) {
     throw new Error('No contact for address ${address}')
   }
-  if(currentContact instanceof SignedPublicKeyBundle) {
+  if (currentContact instanceof SignedPublicKeyBundle) {
     currentContact = currentContact.toLegacyBundle()
   }
-    const intros = await client.listEnvelopes(
-      [buildUserIntroTopic(address)],
-      async (env: any) => {
-        if (!env.message) {
-          throw new Error('No message')
-        }
-        return {
-          timestamp: nsToDate(Long.fromString(env.timestampNs as string)),
-          message: await MessageV1.fromBytes(
-            b64Decode(env.message as unknown as string)
-          ),
-        }
-      },
-      toListOptions(argv)
-    )
-    switch(cmd){
-    case 'check': await check(intros, currentContact); break
-    case 'list': await list(intros, !long); break
-    default: console.log(`invalid command ${cmd}`)
-    }
+  const intros = await client.listEnvelopes(
+    [buildUserIntroTopic(address)],
+    async (env: any) => {
+      if (!env.message) {
+        throw new Error('No message')
+      }
+      return {
+        timestamp: nsToDate(Long.fromString(env.timestampNs as string)),
+        message: await MessageV1.fromBytes(
+          b64Decode(env.message as unknown as string)
+        ),
+      }
+    },
+    toListOptions(argv)
+  )
+  switch (cmd) {
+    case 'check':
+      await check(intros, currentContact)
+      break
+    case 'list':
+      await list(intros, !long)
+      break
+    default:
+      console.log(`invalid command ${cmd}`)
+  }
 }
 
-async function list(intros: { timestamp: Date, message: MessageV1 }[], shouldTruncate = true) {
+async function list(
+  intros: { timestamp: Date; message: MessageV1 }[],
+  shouldTruncate = true
+) {
   let rows = []
-  for(const intro of intros) {
+  for (const intro of intros) {
     const message = intro.message
     rows.push({
       date: intro.timestamp,
-      sender: message.senderAddress ? truncateEthAddress(message.senderAddress, shouldTruncate) : 'undefined',
-      recipient: message.recipientAddress ? truncateEthAddress(message.recipientAddress, shouldTruncate) : 'undefined'
-  })
+      sender: message.senderAddress
+        ? truncateEthAddress(message.senderAddress, shouldTruncate)
+        : 'undefined',
+      recipient: message.recipientAddress
+        ? truncateEthAddress(message.recipientAddress, shouldTruncate)
+        : 'undefined',
+    })
   }
   console.table(rows)
 }
 
-async function check(intros: { timestamp: Date, message: MessageV1 }[], currentContact: PublicKeyBundle) { 
-    let totalIntros = 0
-    let unmatchedContacts = 0
-    for (const { message, timestamp } of intros) {
-      totalIntros++
-      if (!message.header.sender?.preKey || !message.header.recipient?.preKey) {
-        console.log('Broken headers')
-        continue
-      }
-      if (
-        !currentContact.preKey?.equals(
-          new PublicKey(message.header.sender.preKey)
-        ) &&
-        !currentContact.preKey?.equals(
-          new PublicKey(message.header.recipient.preKey)
-        )
-      ) {
-        console.log('Bundles not equal', timestamp)
-        unmatchedContacts++
-      }
+async function check(
+  intros: { timestamp: Date; message: MessageV1 }[],
+  currentContact: PublicKeyBundle
+) {
+  let totalIntros = 0
+  let unmatchedContacts = 0
+  for (const { message, timestamp } of intros) {
+    totalIntros++
+    if (!message.header.sender?.preKey || !message.header.recipient?.preKey) {
+      console.log('Broken headers')
+      continue
     }
-    console.log(`Total intros: ${totalIntros}. Unmatched: ${unmatchedContacts}`)
+    if (
+      !currentContact.preKey?.equals(
+        new PublicKey(message.header.sender.preKey)
+      ) &&
+      !currentContact.preKey?.equals(
+        new PublicKey(message.header.recipient.preKey)
+      )
+    ) {
+      console.log('Bundles not equal', timestamp)
+      unmatchedContacts++
+    }
   }
+  console.log(`Total intros: ${totalIntros}. Unmatched: ${unmatchedContacts}`)
+}

--- a/src/intros.ts
+++ b/src/intros.ts
@@ -22,12 +22,10 @@ export default async function intros(argv: {
 }) {
   const { client, cmd, address, long } = argv
   let currentContact = await client.getUserContact(address)
-  console.log('Got current contact')
   if (!currentContact) {
     throw new Error('No contact for address ${address}')
   }
   if (currentContact instanceof SignedPublicKeyBundle) {
-    console.log('Is signed')
     currentContact = currentContact.toLegacyBundle()
   }
   const intros = await client.listEnvelopes(

--- a/src/intros.ts
+++ b/src/intros.ts
@@ -3,6 +3,7 @@ import {
   PublicKey,
   PublicKeyBundle,
   SignedPublicKeyBundle,
+  Client,
 } from '@xmtp/xmtp-js'
 // @ts-ignore
 import { buildUserIntroTopic, nsToDate } from '@xmtp/xmtp-js/dist/cjs/src/utils'
@@ -13,17 +14,24 @@ import { fetcher } from '@xmtp/proto'
 import { toListOptions, truncateEthAddress } from './utils'
 const { b64Decode } = fetcher
 
-export default async function intros(argv: any) {
+export default async function intros(argv: {
+  client: Client
+  cmd: string
+  address: string
+  long: boolean
+}) {
   const { client, cmd, address, long } = argv
   let currentContact = await client.getUserContact(address)
+  console.log('Got current contact')
   if (!currentContact) {
     throw new Error('No contact for address ${address}')
   }
   if (currentContact instanceof SignedPublicKeyBundle) {
+    console.log('Is signed')
     currentContact = currentContact.toLegacyBundle()
   }
   const intros = await client.listEnvelopes(
-    [buildUserIntroTopic(address)],
+    buildUserIntroTopic(address),
     async (env: any) => {
       if (!env.message) {
         throw new Error('No message')

--- a/src/invites.ts
+++ b/src/invites.ts
@@ -1,33 +1,44 @@
-import { Client } from '@xmtp/xmtp-js'
+import { Client } from "@xmtp/xmtp-js";
 // @ts-ignore
-import { SealedInvitation } from '@xmtp/xmtp-js/dist/cjs/src/Invitation'
+import { SealedInvitation } from "@xmtp/xmtp-js/dist/cjs/src/Invitation";
 // @ts-ignore
-import { buildUserInviteTopic, nsToDate } from '@xmtp/xmtp-js/dist/cjs/src/utils'
-import { toListOptions, truncateEthAddress } from './utils'
-
+import {
+  buildUserInviteTopic,
+  nsToDate,
+} from "@xmtp/xmtp-js;
+import { toListOptions, truncateEthAddress } from "./utils";
 
 export default async function invites(argv: any) {
-    const {client, cmd, address, long} = argv
-    const invites = await client.listEnvelopes(
-        [buildUserInviteTopic(address)],
-        SealedInvitation.fromEnvelope,
-        toListOptions(argv)
-    )
-    switch(cmd){
-    case 'list': await list(invites, !long); break
-    default: console.log(`invalid command ${cmd}`)
-    }
+  const { client, cmd, address, long } = argv;
+  const invites = await client.listEnvelopes(
+    [buildUserInviteTopic(address)],
+    SealedInvitation.fromEnvelope,
+    toListOptions(argv)
+  );
+  switch (cmd) {
+    case "list":
+      await list(invites, !long);
+      break;
+    default:
+      console.log(`invalid command ${cmd}`);
+  }
 }
 
 async function list(invites: SealedInvitation[], truncate = true) {
-    let rows = []
-    for(const invite of invites) {
-        const header = invite.v1.header
-        rows.push({
-        date: nsToDate(header.createdNs),
-        sender: truncateEthAddress(await header.sender.walletSignatureAddress(), truncate),
-        recipient: truncateEthAddress(await header.recipient.walletSignatureAddress(), truncate),
-    })
-    }
-    console.table(rows)
+  let rows = [];
+  for (const invite of invites) {
+    const header = invite.v1.header;
+    rows.push({
+      date: nsToDate(header.createdNs),
+      sender: truncateEthAddress(
+        await header.sender.walletSignatureAddress(),
+        truncate
+      ),
+      recipient: truncateEthAddress(
+        await header.recipient.walletSignatureAddress(),
+        truncate
+      ),
+    });
+  }
+  console.table(rows);
 }

--- a/src/invites.ts
+++ b/src/invites.ts
@@ -1,33 +1,29 @@
-import { Client } from "@xmtp/xmtp-js";
 // @ts-ignore
-import { SealedInvitation } from "@xmtp/xmtp-js/dist/cjs/src/Invitation";
+import { SealedInvitation } from '@xmtp/xmtp-js/dist/cjs/src/Invitation'
 // @ts-ignore
-import {
-  buildUserInviteTopic,
-  nsToDate,
-} from "@xmtp/xmtp-js;
-import { toListOptions, truncateEthAddress } from "./utils";
+import { buildUserInviteTopic, nsToDate } from '@xmtp/xmtp-js'
+import { toListOptions, truncateEthAddress } from './utils'
 
 export default async function invites(argv: any) {
-  const { client, cmd, address, long } = argv;
+  const { client, cmd, address, long } = argv
   const invites = await client.listEnvelopes(
-    [buildUserInviteTopic(address)],
+    buildUserInviteTopic(address),
     SealedInvitation.fromEnvelope,
     toListOptions(argv)
-  );
+  )
   switch (cmd) {
-    case "list":
-      await list(invites, !long);
-      break;
+    case 'list':
+      await list(invites, !long)
+      break
     default:
-      console.log(`invalid command ${cmd}`);
+      console.log(`invalid command ${cmd}`)
   }
 }
 
 async function list(invites: SealedInvitation[], truncate = true) {
-  let rows = [];
+  let rows = []
   for (const invite of invites) {
-    const header = invite.v1.header;
+    const header = invite.v1.header
     rows.push({
       date: nsToDate(header.createdNs),
       sender: truncateEthAddress(
@@ -38,7 +34,7 @@ async function list(invites: SealedInvitation[], truncate = true) {
         await header.recipient.walletSignatureAddress(),
         truncate
       ),
-    });
+    })
   }
-  console.table(rows);
+  console.table(rows)
 }

--- a/src/privateKeys.ts
+++ b/src/privateKeys.ts
@@ -1,16 +1,21 @@
 import { Client } from '@xmtp/xmtp-js'
 // @ts-ignore
-import { buildUserPrivateStoreTopic, nsToDate } from '@xmtp/xmtp-js/dist/cjs/src/utils'
+import {
+  buildUserPrivateStoreTopic,
+  nsToDate,
+} from '@xmtp/xmtp-js/dist/cjs/src/utils'
 import Long from 'long'
 import { toListOptions } from './utils'
 
 export default async function privateKeys(argv: any) {
-    const {client, address} = argv
-    const timestamps = await client.listEnvelopes(
-      [buildUserPrivateStoreTopic(`${address}/key_bundle`)],
-      async (env: any) => {return { date: nsToDate(Long.fromString(env.timestampNs as string)) }},
-      toListOptions(argv)
-    )
-  
-    console.table(timestamps)
-  }
+  const { client, address } = argv
+  const timestamps = await client.listEnvelopes(
+    [buildUserPrivateStoreTopic(`${address}/key_bundle`)],
+    async (env: any) => {
+      return { date: nsToDate(Long.fromString(env.timestampNs as string)) }
+    },
+    toListOptions(argv)
+  )
+
+  console.table(timestamps)
+}

--- a/src/privateKeys.ts
+++ b/src/privateKeys.ts
@@ -1,8 +1,7 @@
-import { Client } from '@xmtp/xmtp-js'
-// @ts-ignore
 import {
   buildUserPrivateStoreTopic,
   nsToDate,
+  // @ts-ignore
 } from '@xmtp/xmtp-js/dist/cjs/src/utils'
 import Long from 'long'
 import { toListOptions } from './utils'
@@ -10,7 +9,7 @@ import { toListOptions } from './utils'
 export default async function privateKeys(argv: any) {
   const { client, address } = argv
   const timestamps = await client.listEnvelopes(
-    [buildUserPrivateStoreTopic(`${address}/key_bundle`)],
+    buildUserPrivateStoreTopic(`${address}/key_bundle`),
     async (env: any) => {
       return { date: nsToDate(Long.fromString(env.timestampNs as string)) }
     },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,73 +1,85 @@
-import { readFileSync, writeFileSync } from 'fs'
-import { ethers, Wallet, utils } from 'ethers'
-import { ListMessagesOptions, SortDirection } from '@xmtp/xmtp-js'
+import { readFileSync, writeFileSync } from "fs";
+import { ethers, Wallet, utils } from "ethers";
+import { ListMessagesOptions, PrivateKey, SortDirection } from "@xmtp/xmtp-js";
 
-const parser = require('any-date-parser')
+const parser = require("any-date-parser");
 
 // Make sure this is in .gitignore
-export const WALLET_FILE_LOCATION = './xmtp_wallet'
+export const WALLET_FILE_LOCATION = "./xmtp_wallet";
+
+export const randomWallet = (): Wallet => {
+  const key = PrivateKey.generate();
+  if (!key.secp256k1) {
+    throw new Error("invalid key");
+  }
+  return new Wallet(key.secp256k1.bytes);
+};
 
 export const saveRandomWallet = () => {
-  const newWallet = Wallet.createRandom()
-  writeFileSync(WALLET_FILE_LOCATION, newWallet.mnemonic.phrase)
-}
-
+  const newWallet = randomWallet();
+  writeFileSync(WALLET_FILE_LOCATION, newWallet.mnemonic.phrase);
+};
 export const loadWallet = () => {
   try {
-    const existing = readFileSync(WALLET_FILE_LOCATION)
-    return Wallet.fromMnemonic(existing.toString())
+    const existing = readFileSync(WALLET_FILE_LOCATION);
+    return Wallet.fromMnemonic(existing.toString());
   } catch (e) {
-    throw new Error('No wallet file found')
+    throw new Error("No wallet file found");
   }
-}
+};
 
-const truncateRegex = /^(0x[a-zA-Z0-9]{4})[a-zA-Z0-9]+([a-zA-Z0-9]{4})$/
+const truncateRegex = /^(0x[a-zA-Z0-9]{4})[a-zA-Z0-9]+([a-zA-Z0-9]{4})$/;
 
 export const truncateEthAddress = (address: string, shouldTruncate = true) => {
-  if (!shouldTruncate) return address
-  const match = address.match(truncateRegex)
-  if (!match) return address
-  return `${match[1]}…${match[2]}`
-}
+  if (!shouldTruncate) return address;
+  const match = address.match(truncateRegex);
+  if (!match) return address;
+  return `${match[1]}…${match[2]}`;
+};
 
 export async function resolveAddress(address: string): Promise<string> {
-  if(!address) {throw new Error(`missing address`)}
-  if (address.startsWith('0x')) {
-    return resolvedAddress(utils.getAddress(address))
+  if (!address) {
+    throw new Error(`missing address`);
   }
-  if (address.endsWith('.eth')) {
-    const resolved = await new ethers.providers.CloudflareProvider().resolveName(address)
-    if(resolved) { return resolvedAddress(resolved) }
+  if (address.startsWith("0x")) {
+    return resolvedAddress(utils.getAddress(address));
   }
-  throw new Error(`Invalid address: ${address}`)
+  if (address.endsWith(".eth")) {
+    const resolved =
+      await new ethers.providers.CloudflareProvider().resolveName(address);
+    if (resolved) {
+      return resolvedAddress(resolved);
+    }
+  }
+  throw new Error(`Invalid address: ${address}`);
 }
 
 function resolvedAddress(address: string): string {
-  console.log(`Resolved address: ${address}`)
-  return address
+  console.log(`Resolved address: ${address}`);
+  return address;
 }
 
 export function toListOptions(argv: any) {
   const options: ListMessagesOptions = {
     direction: argv.desc
       ? SortDirection.SORT_DIRECTION_DESCENDING
-      : SortDirection.SORT_DIRECTION_ASCENDING
+      : SortDirection.SORT_DIRECTION_ASCENDING,
+  };
+  if (argv.start) {
+    options.startTime = parseDate(argv.start, "Starting on");
   }
-  if(argv.start){
-      options.startTime = parseDate(argv.start, "Starting on")
+  if (argv.end) {
+    options.endTime = parseDate(argv.end, "Ending on");
   }
-  if(argv.end){
-    options.endTime = parseDate(argv.end, "Ending on")
+  if (argv.limit) {
+    console.log(`Limited to ${argv.limit}`);
+    options.limit = argv.limit;
   }
-  if(argv.limit) {
-    console.log(`Limited to ${argv.limit}`)
-    options.limit = argv.limit
-  }
-  return options
+  return options;
 }
 
 function parseDate(input: string, msg?: string) {
-  const parsed = parser.fromString(input)
-  console.log(msg, parsed)
-  return parsed instanceof Date ? parsed : undefined
+  const parsed = parser.fromString(input);
+  console.log(msg, parsed);
+  return parsed instanceof Date ? parsed : undefined;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,62 +1,62 @@
-import { readFileSync, writeFileSync } from "fs";
-import { ethers, Wallet, utils } from "ethers";
-import { ListMessagesOptions, PrivateKey, SortDirection } from "@xmtp/xmtp-js";
+import { readFileSync, writeFileSync } from 'fs'
+import { ethers, Wallet, utils } from 'ethers'
+import { ListMessagesOptions, PrivateKey, SortDirection } from '@xmtp/xmtp-js'
 
-const parser = require("any-date-parser");
+const parser = require('any-date-parser')
 
 // Make sure this is in .gitignore
-export const WALLET_FILE_LOCATION = "./xmtp_wallet";
+export const WALLET_FILE_LOCATION = './xmtp_wallet'
 
 export const randomWallet = (): Wallet => {
-  const key = PrivateKey.generate();
+  const key = PrivateKey.generate()
   if (!key.secp256k1) {
-    throw new Error("invalid key");
+    throw new Error('invalid key')
   }
-  return new Wallet(key.secp256k1.bytes);
-};
+  return new Wallet(key.secp256k1.bytes)
+}
 
 export const saveRandomWallet = () => {
-  const newWallet = randomWallet();
-  writeFileSync(WALLET_FILE_LOCATION, newWallet.mnemonic.phrase);
-};
+  const newWallet = randomWallet()
+  writeFileSync(WALLET_FILE_LOCATION, newWallet.mnemonic.phrase)
+}
 export const loadWallet = () => {
   try {
-    const existing = readFileSync(WALLET_FILE_LOCATION);
-    return Wallet.fromMnemonic(existing.toString());
+    const existing = readFileSync(WALLET_FILE_LOCATION)
+    return Wallet.fromMnemonic(existing.toString())
   } catch (e) {
-    throw new Error("No wallet file found");
+    throw new Error('No wallet file found')
   }
-};
+}
 
-const truncateRegex = /^(0x[a-zA-Z0-9]{4})[a-zA-Z0-9]+([a-zA-Z0-9]{4})$/;
+const truncateRegex = /^(0x[a-zA-Z0-9]{4})[a-zA-Z0-9]+([a-zA-Z0-9]{4})$/
 
 export const truncateEthAddress = (address: string, shouldTruncate = true) => {
-  if (!shouldTruncate) return address;
-  const match = address.match(truncateRegex);
-  if (!match) return address;
-  return `${match[1]}…${match[2]}`;
-};
+  if (!shouldTruncate) return address
+  const match = address.match(truncateRegex)
+  if (!match) return address
+  return `${match[1]}…${match[2]}`
+}
 
 export async function resolveAddress(address: string): Promise<string> {
   if (!address) {
-    throw new Error(`missing address`);
+    throw new Error(`missing address`)
   }
-  if (address.startsWith("0x")) {
-    return resolvedAddress(utils.getAddress(address));
+  if (address.startsWith('0x')) {
+    return resolvedAddress(utils.getAddress(address))
   }
-  if (address.endsWith(".eth")) {
+  if (address.endsWith('.eth')) {
     const resolved =
-      await new ethers.providers.CloudflareProvider().resolveName(address);
+      await new ethers.providers.CloudflareProvider().resolveName(address)
     if (resolved) {
-      return resolvedAddress(resolved);
+      return resolvedAddress(resolved)
     }
   }
-  throw new Error(`Invalid address: ${address}`);
+  throw new Error(`Invalid address: ${address}`)
 }
 
 function resolvedAddress(address: string): string {
-  console.log(`Resolved address: ${address}`);
-  return address;
+  console.log(`Resolved address: ${address}`)
+  return address
 }
 
 export function toListOptions(argv: any) {
@@ -64,22 +64,22 @@ export function toListOptions(argv: any) {
     direction: argv.desc
       ? SortDirection.SORT_DIRECTION_DESCENDING
       : SortDirection.SORT_DIRECTION_ASCENDING,
-  };
+  }
   if (argv.start) {
-    options.startTime = parseDate(argv.start, "Starting on");
+    options.startTime = parseDate(argv.start, 'Starting on')
   }
   if (argv.end) {
-    options.endTime = parseDate(argv.end, "Ending on");
+    options.endTime = parseDate(argv.end, 'Ending on')
   }
   if (argv.limit) {
-    console.log(`Limited to ${argv.limit}`);
-    options.limit = argv.limit;
+    console.log(`Limited to ${argv.limit}`)
+    options.limit = argv.limit
   }
-  return options;
+  return options
 }
 
 function parseDate(input: string, msg?: string) {
-  const parsed = parser.fromString(input);
-  console.log(msg, parsed);
-  return parsed instanceof Date ? parsed : undefined;
+  const parsed = parser.fromString(input)
+  console.log(msg, parsed)
+  return parsed instanceof Date ? parsed : undefined
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
@@ -24,7 +24,7 @@
     // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
 
     /* Modules */
-    "module": "commonjs",                                /* Specify what module code is generated. */
+    "module": "commonjs" /* Specify what module code is generated. */,
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
     // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
@@ -32,8 +32,8 @@
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     "typeRoots": [
       "./node_modules/@xmtp/xmtp-js/dist/types"
-    ],                                  /* Specify multiple folders that act like `./node_modules/@types`. */
-    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    ] /* Specify multiple folders that act like `./node_modules/@types`. */,
+    "types": [] /* Specify type package names to be included without being referenced in a source file. */,
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "resolveJsonModule": true,                        /* Enable importing .json files */
     // "noResolve": true,                                /* Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project. */
@@ -49,7 +49,7 @@
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output. */
-    "outDir": "./dist",                                   /* Specify an output folder for all emitted files. */
+    "outDir": "./dist" /* Specify an output folder for all emitted files. */,
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
@@ -71,12 +71,12 @@
     /* Interop Constraints */
     // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
     // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility. */
+    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility. */,
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
 
     /* Type Checking */
-    "strict": true,                                      /* Enable all strict type-checking options. */
+    "strict": true /* Enable all strict type-checking options. */,
     // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied `any` type.. */
     // "strictNullChecks": true,                         /* When type checking, take into account `null` and `undefined`. */
     // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
@@ -98,6 +98,7 @@
 
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
-  }
+    "skipLibCheck": true /* Skip type checking all .d.ts files. */
+  },
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
## Summary
- Adds a new method to fill a user's invite topic with a specified number of invites (and messages in each conversation). This can be used to create pathological accounts, which are useful for debugging issues in clients.
- Adds a prettierrc.js matching `xmtp-js`. I couldn't get my formatter to match whatever style was applied to the files before otherwise.
- Upgrades to latest version of `xmtp-js` and `@xmtp/proto`