### PR TITLE
feat: contact bundle invariant checker

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,7 +1,7 @@
 module.exports = {
   semi: false,
   singleQuote: true,
-  trailingComma: "es5",
-  arrowParens: "always",
+  trailingComma: 'es5',
+  arrowParens: 'always',
   printWidth: 80,
-};
+}

--- a/src/contacts.ts
+++ b/src/contacts.ts
@@ -135,8 +135,14 @@ async function verify(address: string, contacts: Contact[]) {
       let joinedErrors = errors.join(',')
       rows.push({
         date: timestamp,
-        type: contact instanceof PublicKeyBundle ? 'v1' : 'v2',
+        type: 'v1',
         errors: joinedErrors.length > 0 ? joinedErrors : 'ok',
+      })
+    } else if (contact instanceof SignedPublicKeyBundle) {
+      rows.push({
+        date: timestamp,
+        type: 'v2',
+        errors: 'v2 checking not implemented',
       })
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,11 @@ yargs(hideBin(process.argv))
     'contacts [cmd] [address]',
     'list/check published contacts for the address',
     {
-      cmd: { type: 'string', choices: ['check', 'list', 'dump'], default: 'list' },
+      cmd: {
+        type: 'string',
+        choices: ['check', 'list', 'dump', 'verify'],
+        default: 'list',
+      },
       address: { type: 'string' },
     },
     async (argv: any) => {

--- a/src/verify_utils.ts
+++ b/src/verify_utils.ts
@@ -30,7 +30,7 @@ export function verifyIdentityKeyV1(keybundle: PublicKeyBundle) {
     if (identityKey.secp256k1Uncompressed) {
       const idkey = identityKey.secp256k1Uncompressed.bytes
       if (idkey.length !== 65) {
-        errors.push('idkey_bad')
+        errors.push('idkey_bad_len_' + idkey.length)
       }
     }
   }
@@ -83,7 +83,7 @@ export async function verifyPreKeyV1(keybundle: PublicKeyBundle) {
     if (preKey.secp256k1Uncompressed) {
       const prekey = preKey.secp256k1Uncompressed.bytes
       if (prekey.length !== 65) {
-        errors.push('prekey_bad')
+        errors.push('prekey_bad_len_' + prekey.length)
       }
     }
   }

--- a/src/verify_utils.ts
+++ b/src/verify_utils.ts
@@ -25,6 +25,8 @@ export function verifyIdentityKeyV1(keybundle: PublicKeyBundle) {
     errors.push('idkey_missing')
     return errors
   } else {
+    // Direct quote from BIP-137 (Just quoted for their description of a known key format)
+    // The older uncompressed keys are 65 bytes, consisting of constant prefix (0x04), followed by two 256-bit integers called x and y (2 * 32 bytes).
     if (identityKey.secp256k1Uncompressed) {
       const idkey = identityKey.secp256k1Uncompressed.bytes
       if (idkey.length !== 65) {
@@ -53,6 +55,9 @@ export function verifyIdentityKeySignatureV1(
     return errors
   }
   const idkeySig = identityKey.signature.ecdsaCompact.bytes
+  // Signatures in proto form are (r, s) where r and s are 32 bytes each
+  // The v can be appended to form a 65 byte signature, but in our case we
+  // carry the recovery id separately
   if (idkeySig.length !== 64) {
     errors.push('idkey_sig_bad_len_' + idkeySig.length)
     return errors

--- a/src/verify_utils.ts
+++ b/src/verify_utils.ts
@@ -1,0 +1,63 @@
+import { SignedPublicKeyBundle, PublicKeyBundle } from '@xmtp/xmtp-js'
+
+export function verifyIdentityKeyV1(keybundle: PublicKeyBundle) {
+  let errors: string[] = []
+  let identityKey = keybundle.identityKey
+  if (!identityKey) {
+    errors.push('idkey_missing')
+    return errors
+  }
+  if (!identityKey.secp256k1Uncompressed) {
+    errors.push('idkey_missing')
+    return errors
+  } else {
+    if (identityKey.secp256k1Uncompressed) {
+      const idkey = identityKey.secp256k1Uncompressed.bytes
+      if (idkey.length !== 65) {
+        errors.push('idkey_bad')
+      }
+    }
+  }
+  return errors
+}
+
+export function verifyIdentityKeySignatureV1(keybundle: PublicKeyBundle) {
+  let errors: string[] = []
+  let identityKey = keybundle.identityKey
+  if (!identityKey) {
+    return errors
+  }
+  if (!identityKey.signature) {
+    errors.push('idkey_sig_missing')
+    return errors
+  }
+  if (!identityKey.signature.ecdsaCompact) {
+    errors.push('idkey_wrong_sig_type')
+    return errors
+  }
+  const idkeySig = identityKey.signature.ecdsaCompact.bytes
+  if (idkeySig.length !== 64) {
+    errors.push('idkey_sig_bad_len_' + idkeySig.length)
+  }
+  return errors
+}
+
+export function verifyPreKeyV1(keybundle: PublicKeyBundle) {
+  let errors: string[] = []
+  let preKey = keybundle.preKey
+  if (!preKey) {
+    return errors
+  }
+  if (!preKey.secp256k1Uncompressed) {
+    errors.push('prekey_missing')
+    return errors
+  } else {
+    if (preKey.secp256k1Uncompressed) {
+      const prekey = preKey.secp256k1Uncompressed.bytes
+      if (prekey.length !== 65) {
+        errors.push('prekey_bad')
+      }
+    }
+  }
+  return errors
+}


### PR DESCRIPTION
## Overview

Related: https://github.com/xmtp/xmtp-flutter/pull/67

This implements a V1 contact bundle invariant checker so we can debug issues like this (or maybe even fix them) in the future. The goal is to check less well-known (becoming even more forgotten every day) invariants that developed over time. For example, V2 contact bundles expect different signature submessage fields from V1 - even though the underlying signature is the same format.

We add a new `verify` command. It's possible it could be unified with `dump` or `check` but currently doesn't exactly agree with the semantics. The `verify` command prints a list of short error descriptions for each contact bundle.

**NOTE** only supports V1 contact bundle checking at the moment.

## Test Plan

### Invalid Contact from issue
```
> node --no-warnings ./dist/index.js "--env=production" "contacts" "verify" "0xXXXXXXXXXXXXXXXXX"

XMTP environment: production
Resolved address: 0xXXXXXXXXXXXXXXXXX
┌─────────┬──────────────────────────┬──────┬───────────────────────────────┐
│ (index) │           date           │ type │            errors             │
├─────────┼──────────────────────────┼──────┼───────────────────────────────┤
│    0    │ 2023-XX-XXTXX:XX:XX.XXXZ │ 'v1' │ 'idkey_wrong_sig_type_wallet' │
│    1    │ 2023-XX-XXTXX:XX:XX.XXXZ │ 'v2' │ 'v2 checking not implemented' │
└─────────┴──────────────────────────┴──────┴───────────────────────────────┘
```

### Valid contact (my own wallet)
```
> node --no-warnings ./dist/index.js "--env=production" "contacts" "verify" "0x6e78a3f4D522c810dc272aBe945b1B9FbD624c4F"

XMTP environment: production
Resolved address: 0x6e78a3f4D522c810dc272aBe945b1B9FbD624c4F
┌─────────┬──────────────────────────┬──────┬───────────────────────────────┐
│ (index) │           date           │ type │            errors             │
├─────────┼──────────────────────────┼──────┼───────────────────────────────┤
│    0    │ 2023-04-20T19:56:00.314Z │ 'v1' │             'ok'              │
│    1    │ 2023-04-20T19:56:00.406Z │ 'v2' │ 'v2 checking not implemented' │
└─────────┴──────────────────────────┴──────┴───────────────────────────────┘
```
