### PR TITLE
feat: verify v2 contact bundles

### DIFF
--- a/src/contacts.ts
+++ b/src/contacts.ts
@@ -131,7 +131,7 @@ async function verify(address: string, contacts: Contact[]) {
   let rows = []
   for (const { timestamp, contact } of contacts) {
     let errors = []
-    // TODO: verify v2
+    // Verify v1
     if (contact instanceof PublicKeyBundle) {
       const { identityKey, preKey } = contact
       let idKeyErrors = verifyIdentityKeyV1(contact)
@@ -148,12 +148,14 @@ async function verify(address: string, contacts: Contact[]) {
         errors: joinedErrors.length > 0 ? joinedErrors : 'ok',
       })
     } else if (contact instanceof SignedPublicKeyBundle) {
+      // Verify v2
       let idKeyErrors = verifyIdentityKeyV2(contact)
       errors.push(...idKeyErrors)
       let idkeySigErrors = await verifyIdentityKeySignatureV2(address, contact)
       errors.push(...idkeySigErrors)
       let preKeyErrors = await verifyPreKeyV2(contact)
       errors.push(...preKeyErrors)
+
       let joinedErrors = errors.join(',')
       rows.push({
         date: timestamp,

--- a/src/verify_utils.ts
+++ b/src/verify_utils.ts
@@ -96,10 +96,128 @@ export async function verifyPreKeyV1(keybundle: PublicKeyBundle) {
   // Need to get the payload from prekey bytesToSign
   if (!preKey.signature) {
     errors.push('prekey_sig_missing')
-    if (!preKey.signature!.ecdsaCompact) {
-      errors.push('prekey_wrong_sig_type_wallet')
-      return errors
+    return errors
+  }
+  if (!preKey.signature!.ecdsaCompact) {
+    errors.push('prekey_wrong_sig_type_wallet')
+    return errors
+  }
+  // Check that the prekey is signed by the identity key
+  let digest = await sha256(preKey.bytesToSign())
+  let recoveredKey = preKey.signature!.getPublicKey(digest)
+  const identityKeyHex = bytesToHex(identityKey.secp256k1Uncompressed.bytes)
+  if (!recoveredKey) {
+    errors.push('prekey_sig_bad_recovers_to_null')
+    return errors
+  }
+  const recoveredKeyHex = bytesToHex(recoveredKey!.secp256k1Uncompressed.bytes)
+  if (identityKeyHex !== recoveredKeyHex) {
+    errors.push('prekey_not_signed_by_idkey')
+  }
+  return errors
+}
+
+// V2 contact bundle checks
+// Major difference is the SignedPublicKeyBundle embeds SignedPublicKeys
+// - A SignedPublicKey embeds 1) the serialized proto of an UnsignedPublicKey and 2) a Signature
+export function verifyIdentityKeyV2(keybundle: SignedPublicKeyBundle) {
+  let errors: string[] = []
+  let identityKey = keybundle.identityKey
+  if (!identityKey) {
+    errors.push('idkey_missing')
+    return errors
+  }
+  if (!identityKey.unsignedKey) {
+    errors.push('idkey_missing_embedded_unsigned_key')
+    return errors
+  }
+  // Parse an UnsignedPublicKey from the identityKey.key_bytes using the helper accessor
+  let identityKeyUnsigned = identityKey.unsignedKey
+  if (!identityKeyUnsigned.secp256k1Uncompressed) {
+    errors.push('idkey_embedded_unsigned_key_missing_secp256k1')
+    return errors
+  } else {
+    // Direct quote from BIP-137 (Just quoted for their description of a known key format)
+    // The older uncompressed keys are 65 bytes, consisting of constant prefix (0x04), followed by two 256-bit integers called x and y (2 * 32 bytes).
+    if (identityKey.secp256k1Uncompressed) {
+      const idkey = identityKey.secp256k1Uncompressed.bytes
+      if (idkey.length !== 65) {
+        errors.push('idkey_bad_len_' + idkey.length)
+      }
     }
+  }
+  return errors
+}
+
+// Check the wallet signature on the identity key, expect walletEcdsaCompact
+// and check that it recovers to the correct address
+export async function verifyIdentityKeySignatureV2(
+  address: string,
+  keybundle: SignedPublicKeyBundle
+) {
+  let errors: string[] = []
+  let identityKey = keybundle.identityKey
+  if (!identityKey) {
+    return errors
+  }
+  if (!identityKey.signature) {
+    errors.push('idkey_sig_missing')
+    return errors
+  }
+  if (!identityKey.signature.walletEcdsaCompact) {
+    errors.push('idkey_wrong_sig_type_nonwallet')
+    return errors
+  }
+  const idkeySig = identityKey.signature.walletEcdsaCompact.bytes
+  // Signatures in proto form are (r, s) where r and s are 32 bytes each
+  // The v can be appended to form a 65 byte signature, but in our case we
+  // carry the recovery id separately
+  if (idkeySig.length !== 64) {
+    errors.push('idkey_sig_bad_len_' + idkeySig.length)
+    return errors
+  }
+  // Check that the signature recovers to the correct address, under the hood
+  // this deserializes the embeded unsigned_key and checks the signature
+  const recoveredAddress = await identityKey.walletSignatureAddress()
+  if (recoveredAddress !== address) {
+    errors.push('idkey_sig_bad_recovers_to_' + truncateHex(recoveredAddress))
+  }
+  return errors
+}
+
+// Check prekey, then check that it's signed by the identity key. Expect ecdsaCompact.
+export async function verifyPreKeyV2(keybundle: SignedPublicKeyBundle) {
+  let errors: string[] = []
+  let preKey = keybundle.preKey
+  if (!preKey) {
+    return errors
+  }
+  if (!preKey.unsignedKey) {
+    errors.push('prekey_missing')
+    return errors
+  } else {
+    if (preKey.unsignedKey.secp256k1Uncompressed) {
+      const prekey = preKey.unsignedKey.secp256k1Uncompressed.bytes
+      if (prekey.length !== 65) {
+        errors.push('prekey_bad_len_' + prekey.length)
+      }
+    }
+  }
+  let identityKey = keybundle.identityKey
+  if (!identityKey || !identityKey.unsignedKey?.secp256k1Uncompressed) {
+    // missing identity key should be caught by verifyIdentityKeyV2
+    return errors
+  }
+  // Check that the prekey signature is valid and signed by the identity key
+  // Need to get the payload from prekey bytesToSign
+  if (!preKey.signature) {
+    errors.push('prekey_sig_missing')
+    return errors
+  }
+  // This should be ecdsaCompact because we're using the identity key (non-wallet) to sign the prekey
+  if (!preKey.signature!.ecdsaCompact) {
+    errors.push('prekey_wrong_sig_type_wallet')
+    return errors
   }
   // Check that the prekey is signed by the identity key
   let digest = await sha256(preKey.bytesToSign())


### PR DESCRIPTION
## Overview

Follow-up on #4 by implementing V2 contact bundle checking. This relies heavily on `xmtp-js` under the hood, it does the heavy lifting with deserializing the embedded `unsigned_key` bytes.


## Test Plan

Ran it on the mixed up wallet
```
> node --no-warnings ./dist/index.js "--env=production" "contacts" "verify" "0x00000000000000000"

XMTP environment: production
Resolved address: 0x00000000000000000
┌─────────┬──────────────────────────┬──────┬───────────────────────────────┐
│ (index) │           date           │ type │            errors             │
├─────────┼──────────────────────────┼──────┼───────────────────────────────┤
│    0    │ 2023-XX-XXTXX:XX:XX.XXXZ │ 'v1' │ 'idkey_wrong_sig_type_wallet' │
│    1    │ 2023-XX-XXTXX:XX:XX.XXXZ │ 'v2' │             'ok'              │
└─────────┴──────────────────────────┴──────┴───────────────────────────────┘
```