### PR TITLE
feat: add a new crosscheck command which runs multiple checks

### DIFF
--- a/src/contacts.ts
+++ b/src/contacts.ts
@@ -127,13 +127,12 @@ async function check(contacts: Contact[]) {
 
 // Check for dev/prod confusion i.e. where a client mistakenly uploads
 // prod contacts to dev or vice versa
-// NOTE: this requires ignoring the environment flag and checking against both environments
 export function crosscheckContacts(
   devContacts: Contact[],
   prodContacts: Contact[]
 ) {
-  // Look for any identity keys that are the same in both environments. The identity key
-  // and an prekeys should be unique per environment.
+  // Look for any identity keys that are the same in both environments. The identity key should
+  // be unique per environment (generated randomly and independently)
   const devIdentityKeys = new Set<string>()
   const prodIdentityKeys = new Set<string>()
   for (const contact of devContacts) {
@@ -151,7 +150,7 @@ export function crosscheckContacts(
   )
   if (intersection.size > 0) {
     // Return an error message
-    return `Found ${intersection.size} identity keys that are the same in both environments. The identity key and prekeys should be unique per environment.`
+    return `Found ${intersection.size} identity keys that are the same in both environments. The identity key should be unique per environment.`
   }
   return null
 }

--- a/src/crosscheck.ts
+++ b/src/crosscheck.ts
@@ -1,0 +1,35 @@
+import { getContactsWithClient, crosscheckContacts, verify } from './contacts'
+
+export default async function crosscheck(argv: any) {
+  // Expect devClient, prodClient
+  const { devClient, prodClient, address } = argv
+  const devContacts = await getContactsWithClient(devClient, address, argv)
+  const prodContacts = await getContactsWithClient(prodClient, address, argv)
+
+  // Rows are format: check, status, message
+  let rows = []
+  // Use contacts.crosscheckContacts to check for dev/prod confusion
+  let devProdConfusionError = crosscheckContacts(devContacts, prodContacts)
+  if (devProdConfusionError) {
+    rows.push(['dev/prod confusion', 'FAIL', devProdConfusionError])
+  } else {
+    rows.push([
+      'dev/prod confusion',
+      'PASS',
+      `No intermixed contacts. Found ${devContacts.length} dev contacts and ${prodContacts.length} prod contacts`,
+    ])
+  }
+  console.table(rows)
+  // Create artificial commands for contacts.verify on both dev and prod
+  // Use contacts.verify to check for malformed contacts, this function prints its own output
+  if (devContacts.length === 0) {
+    console.table(['dev contacts', 'SKIP', 'No contacts to verify'])
+  } else {
+    await verify(address, devContacts)
+  }
+  if (prodContacts.length === 0) {
+    console.table(['prod contacts', 'SKIP', 'No contacts to verify'])
+  } else {
+    await verify(address, prodContacts)
+  }
+}

--- a/src/crosscheck.ts
+++ b/src/crosscheck.ts
@@ -11,25 +11,39 @@ export default async function crosscheck(argv: any) {
   // Use contacts.crosscheckContacts to check for dev/prod confusion
   let devProdConfusionError = crosscheckContacts(devContacts, prodContacts)
   if (devProdConfusionError) {
-    rows.push(['dev/prod confusion', 'FAIL', devProdConfusionError])
+    rows.push({
+      check: 'dev/prod confusion',
+      status: 'FAIL',
+      error: devProdConfusionError,
+    })
   } else {
-    rows.push([
-      'dev/prod confusion',
-      'PASS',
-      `No intermixed contacts. Found ${devContacts.length} dev contacts and ${prodContacts.length} prod contacts`,
-    ])
+    rows.push({
+      check: 'dev/prod confusion',
+      status: 'PASS',
+      error: `No intermixed contacts. Found ${devContacts.length} dev contacts and ${prodContacts.length} prod contacts`,
+    })
   }
   console.table(rows)
   // Create artificial commands for contacts.verify on both dev and prod
   // Use contacts.verify to check for malformed contacts, this function prints its own output
   if (devContacts.length === 0) {
-    console.table(['dev contacts', 'SKIP', 'No contacts to verify'])
+    console.table([
+      { check: 'dev contacts', status: 'SKIP - No contacts to verify' },
+    ])
   } else {
+    console.table([
+      { check: 'Checking dev contact bundle integrity', status: 'RUN' },
+    ])
     await verify(address, devContacts)
   }
   if (prodContacts.length === 0) {
-    console.table(['prod contacts', 'SKIP', 'No contacts to verify'])
+    console.table([
+      { check: 'prod contacts', status: 'SKIP - No contacts to verify' },
+    ])
   } else {
+    console.table([
+      { check: 'Checking prod contact bundle integrity', status: 'RUN' },
+    ])
     await verify(address, prodContacts)
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,7 +108,7 @@ yargs(hideBin(process.argv))
   )
   .command(
     'crosscheck [address]',
-    `A metacommand to check a given address for common issues like dev/prod confusion (i.e. dev contact bundle on prod)`,
+    `Run a given address through a suite of checks for  known issues like dev/prod confusion (i.e. dev contact bundle on prod)`,
     {
       address: { type: 'string' },
     },


### PR DESCRIPTION
## Overview

My overarching goal is to automate some non-trivial percentage of guesswork when it comes to diagnosing user issues. Currently the `crosscheck` command will check for:

1) dev/prod confusion - contact bundles being uploaded to the wrong environment
2) contact bundle validity for v1/v2 - looking for an issue like #https://github.com/xmtp/xmtp-flutter/pull/67

If ya'll have any ideas for other possible checks I'd love to add them here!

## Test Plan

Running on a wallet that suffered from dev/prod confusion
```
> node --no-warnings ./dist/index.js "crosscheck" "0x0000000000000000000000"

XMTP environment: dev
...
Connected to the XMTP 'dev' network. Use 'production' for production messages.
https://github.com/xmtp/xmtp-js#xmtp-production-and-dev-network-environments

Resolved address: 0x0000000000000000000000
┌─────────┬──────────────────────┬────────┬────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ (index) │          0           │   1    │                                                               2                                                                │
├─────────┼──────────────────────┼────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│    0    │ 'dev/prod confusion' │ 'FAIL' │ 'Found 1 identity keys that are the same in both environments. The identity key and prekeys should be unique per environment.' │
└─────────┴──────────────────────┴────────┴────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
┌─────────┬──────────────────────────┬──────┬────────┐
│ (index) │           date           │ type │ errors │
├─────────┼──────────────────────────┼──────┼────────┤
│    0    │ 2022-06-08T21:42:55.997Z │ 'v1' │  'ok'  │
│    1    │ 2022-06-08T21:47:11.957Z │ 'v1' │  'ok'  │
│    2    │ 2022-06-08T22:13:30.792Z │ 'v1' │  'ok'  │
│    3    │ 2022-06-08T23:28:19.366Z │ 'v1' │  'ok'  │
│    4    │ 2022-06-08T23:45:07.746Z │ 'v1' │  'ok'  │
...
```