### PR TITLE
Add loadtesting for invites

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@xmtp/proto": "3.24.0-beta.2",
-        "@xmtp/xmtp-js": "^8.2.1",
+        "@xmtp/xmtp-js": "^9.1.3",
         "any-date-parser": "^1.5.3",
         "ethers": "^5.7.2",
         "yargs": "^17.6.2"
@@ -885,9 +885,9 @@
       }
     },
     "node_modules/@xmtp/xmtp-js": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/@xmtp/xmtp-js/-/xmtp-js-8.2.1.tgz",
-      "integrity": "sha512-mksNK6IvPPLkMLQbC5dmvavp8+T44cBrRWF4+/Zyu4jH+jJNXDqp8VFwfWGjdMy0k28IJGNruOYX65qmv+Wq5Q==",
+      "version": "9.1.5",
+      "resolved": "https://registry.npmjs.org/@xmtp/xmtp-js/-/xmtp-js-9.1.5.tgz",
+      "integrity": "sha512-wBrDi3MHWFR6FnjLlciaFALcs+HvMxMdjmAEOekt8bFwbYsLTw5QnXbO6Xz0nT6tEfofAK2JCPjDY9CaXI3kWg==",
       "dependencies": {
         "@noble/secp256k1": "^1.5.2",
         "@xmtp/proto": "^3.24.0",
@@ -2817,9 +2817,9 @@
       }
     },
     "@xmtp/xmtp-js": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/@xmtp/xmtp-js/-/xmtp-js-8.2.1.tgz",
-      "integrity": "sha512-mksNK6IvPPLkMLQbC5dmvavp8+T44cBrRWF4+/Zyu4jH+jJNXDqp8VFwfWGjdMy0k28IJGNruOYX65qmv+Wq5Q==",
+      "version": "9.1.5",
+      "resolved": "https://registry.npmjs.org/@xmtp/xmtp-js/-/xmtp-js-9.1.5.tgz",
+      "integrity": "sha512-wBrDi3MHWFR6FnjLlciaFALcs+HvMxMdjmAEOekt8bFwbYsLTw5QnXbO6Xz0nT6tEfofAK2JCPjDY9CaXI3kWg==",
       "requires": {
         "@noble/secp256k1": "^1.5.2",
         "@xmtp/proto": "^3.24.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@xmtp/proto": "3.24.0-beta.2",
-    "@xmtp/xmtp-js": "^8.2.1",
+    "@xmtp/xmtp-js": "^9.1.3",
     "any-date-parser": "^1.5.3",
     "ethers": "^5.7.2",
     "yargs": "^17.6.2"

--- a/src/contacts.ts
+++ b/src/contacts.ts
@@ -3,11 +3,11 @@ import {
   buildUserContactTopic,
   nsToDate,
   // @ts-ignore
-} from '@xmtp/xmtp-js/dist/cjs/src/utils'
+} from '@xmtp/xmtp-js'
 // @ts-ignore
-import { decodeContactBundle } from '@xmtp/xmtp-js/dist/cjs/src/ContactBundle'
+import { decodeContactBundle } from '@xmtp/xmtp-js'
 // @ts-ignore
-import { bytesToHex } from '@xmtp/xmtp-js/dist/cjs/src/crypto/utils'
+import { bytesToHex } from '@xmtp/xmtp-js'
 import Long from 'long'
 import { fetcher } from '@xmtp/proto'
 import { toListOptions } from './utils'

--- a/src/fillConversationList.ts
+++ b/src/fillConversationList.ts
@@ -1,5 +1,10 @@
 import { Client } from '@xmtp/xmtp-js'
-import { randomWallet, resolveAddress } from './utils'
+import { randomWallet, resolveAddress, appVersion } from './utils'
+
+// See rule "publish" in https://github.com/xmtp-labs/infrastructure/blob/main/plans/production/public_load_balancer.tf
+const wafLimit = 1000 // publish calls per IP
+const wafLimitPeriodMs = 300000 // 5 min
+const nonMessageCallsPerConvo = 5 // 2 * invite + 2 * contact + 1 * private key bundle
 
 export default async function fillInvites(argv: any) {
   const { env, address: rawAddress, numInvites, numMessagesPerConvo } = argv
@@ -7,17 +12,30 @@ export default async function fillInvites(argv: any) {
   console.log(
     `Sending ${numInvites} invites to ${address} and sending ${numMessagesPerConvo} messages per invite`
   )
-
-  await Promise.all(
-    Array.from({ length: numInvites }, async (_, i) => {
-      const client = await Client.create(randomWallet(), { env })
-      const convo = await client.conversations.newConversation(address, {
-        conversationId: `xmtp.org/test/${i}`,
-        metadata: {},
+  const batchSize = wafLimit / (numMessagesPerConvo + nonMessageCallsPerConvo)
+  let remaining = numInvites
+  while (remaining > 0) {
+    const batch = remaining < batchSize ? remaining : batchSize
+    remaining -= batch
+    const start = Date.now()
+    await Promise.all(
+      Array.from({ length: batch }, async (_, i) => {
+        const client = await Client.create(randomWallet(), { env, appVersion })
+        const convo = await client.conversations.newConversation(address, {
+          conversationId: `xmtp.org/test/${remaining+i}`,
+          metadata: {},
+        })
+        for (let j = 0; j < numMessagesPerConvo; j++) {
+          await convo.send(`gm ${j}`)
+        }
       })
-      for (let j = 0; j < numMessagesPerConvo; j++) {
-        await convo.send(`gm ${j}`)
-      }
-    })
-  )
+    )
+    console.log(`Created ${batch} conversations`)
+    if (remaining > 0) {
+      // wait until the WAF limit 1000 publishes / 5 min expires
+      const delay = start - Date.now() + wafLimitPeriodMs
+      console.log(`Waiting ${delay} ms for the next WAF limit window`)
+      await new Promise((resolve) => setTimeout(() => resolve(null), delay))
+    }
+  }
 }

--- a/src/intros.ts
+++ b/src/intros.ts
@@ -6,9 +6,9 @@ import {
   Client,
 } from '@xmtp/xmtp-js'
 // @ts-ignore
-import { buildUserIntroTopic, nsToDate } from '@xmtp/xmtp-js/dist/cjs/src/utils'
+import { buildUserIntroTopic, nsToDate } from '@xmtp/xmtp-js'
 // @ts-ignore
-import { MessageV1 } from '@xmtp/xmtp-js/dist/cjs/src/Message'
+import { MessageV1 } from '@xmtp/xmtp-js'
 import Long from 'long'
 import { fetcher } from '@xmtp/proto'
 import { toListOptions, truncateEthAddress } from './utils'

--- a/src/invites.ts
+++ b/src/invites.ts
@@ -1,31 +1,47 @@
 // @ts-ignore
-import { SealedInvitation } from '@xmtp/xmtp-js/dist/cjs/src/Invitation'
+import { SealedInvitation } from '@xmtp/xmtp-js'
 import {
   buildUserInviteTopic,
   nsToDate,
   // @ts-ignore
-} from '@xmtp/xmtp-js/dist/cjs/src/utils'
-import { toListOptions, truncateEthAddress } from './utils'
+} from '@xmtp/xmtp-js'
+import { toListOptions, toPaginatedListOptions, truncateEthAddress } from './utils'
 
 export default async function invites(argv: any) {
-  const { client, cmd, address, full } = argv
-  const invites = await client.listEnvelopes(
+  const { client, cmd, address, full, page, batchSize, batchCount } = argv
+  const loadEnvelopes = page ?
+    async () => {
+      let invites: SealedInvitation[] = []
+      for await (const page of client.listEnvelopesPaginated(
+        buildUserInviteTopic(address),
+        SealedInvitation.fromEnvelope,
+        toPaginatedListOptions(argv))) {
+          invites = invites.concat(page)
+        }
+        return invites
+    } :
+    () => client.listEnvelopes(
     buildUserInviteTopic(address),
     SealedInvitation.fromEnvelope,
     toListOptions(argv)
   )
   switch (cmd) {
     case 'list':
-      await list(invites, !full)
+      await list(loadEnvelopes, !full)
+      break
+    case 'load':
+      await load(loadEnvelopes, batchSize, batchCount)
       break
     default:
       console.log(`invalid command ${cmd}`)
   }
 }
 
-async function list(invites: SealedInvitation[], truncate = true) {
+async function list(loadEnvelopes: () => Promise<SealedInvitation[]>, truncate = true) {
+  const invites = await loadEnvelopes()
   let rows = []
   for (const invite of invites) {
+    if (!invite.v1) continue
     const header = invite.v1.header
     rows.push({
       date: nsToDate(header.createdNs),
@@ -40,4 +56,28 @@ async function list(invites: SealedInvitation[], truncate = true) {
     })
   }
   console.table(rows)
+}
+
+async function load(loadEnvelopes: () => Promise<SealedInvitation[]>, batchSize: number, batchCount: number) {
+  console.log(`running ${batchCount} load tests with ${batchSize} parallel loads each`)
+  for (let i = 0; i < batchCount; i++) {
+    console.log(`${new Date().toISOString()} started batch ${i}`);
+    const results = await Promise.allSettled(
+      Array.from({ length: batchSize }, async (_, i) => loadEnvelopes()))
+    const totals = results.reduce(addResult, new Map())
+    for (const [k,v] of totals) {
+      console.log(`${k} = ${v}`)
+    }
+  }
+}
+
+function incKey(results: Map<string, number>, key: string): Map<string, number> {
+  results.set(key, 1 + (results.get(key) || 0))
+  return results
+}
+
+function addResult(results: Map<string, number>, result: PromiseSettledResult<any>): Map<string, number> {
+  return result.status == "fulfilled" ?
+    incKey(results, `results ${result.value.length}`) :
+    incKey(results, result.reason.toString())
 }

--- a/src/privateKeys.ts
+++ b/src/privateKeys.ts
@@ -2,7 +2,7 @@ import {
   buildUserPrivateStoreTopic,
   nsToDate,
   // @ts-ignore
-} from '@xmtp/xmtp-js/dist/cjs/src/utils'
+} from '@xmtp/xmtp-js'
 import Long from 'long'
 import { toListOptions } from './utils'
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,8 @@
 import { readFileSync, writeFileSync } from 'fs'
 import { ethers, Wallet, utils } from 'ethers'
-import { ListMessagesOptions, PrivateKey, SortDirection } from '@xmtp/xmtp-js'
+import { ListMessagesOptions, ListMessagesPaginatedOptions, SortDirection } from '@xmtp/xmtp-js'
+
+export const appVersion = "xmtp-debug"
 
 const parser = require('any-date-parser')
 
@@ -56,26 +58,47 @@ function resolvedAddress(address: string): string {
 }
 
 export function toListOptions(argv: any) {
+  const shouldLog = argv.cmd != "load"
   const options: ListMessagesOptions = {
     direction: argv.desc
       ? SortDirection.SORT_DIRECTION_DESCENDING
       : SortDirection.SORT_DIRECTION_ASCENDING,
   }
   if (argv.start) {
-    options.startTime = parseDate(argv.start, 'Starting on')
+    options.startTime = parseDate(argv.start, shouldLog ? 'Starting on' : undefined)
   }
   if (argv.end) {
-    options.endTime = parseDate(argv.end, 'Ending on')
+    options.endTime = parseDate(argv.end, shouldLog ? 'Ending on' : undefined)
   }
   if (argv.limit) {
-    console.log(`Limited to ${argv.limit}`)
+    if (shouldLog) console.log(`Limited to ${argv.limit}`)
     options.limit = argv.limit
+  }
+  return options
+}
+
+export function toPaginatedListOptions(argv: any) {
+  const shouldLog = argv.cmd != "load"
+  const options: ListMessagesPaginatedOptions = {
+    direction: argv.desc
+      ? SortDirection.SORT_DIRECTION_DESCENDING
+      : SortDirection.SORT_DIRECTION_ASCENDING,
+  }
+  if (argv.start) {
+    options.startTime = parseDate(argv.start, shouldLog ? 'Starting on' : undefined)
+  }
+  if (argv.end) {
+    options.endTime = parseDate(argv.end, shouldLog ? 'Ending on' : undefined)
+  }
+  if (argv.page) {
+    if (shouldLog) console.log(`Paging by ${argv.page}`)
+    options.pageSize = argv.page
   }
   return options
 }
 
 function parseDate(input: string, msg?: string) {
   const parsed = parser.fromString(input)
-  console.log(msg, parsed)
+  if (msg) console.log(msg, parsed)
   return parsed instanceof Date ? parsed : undefined
 }

--- a/src/verify_utils.ts
+++ b/src/verify_utils.ts
@@ -1,8 +1,8 @@
 import { SignedPublicKeyBundle, PublicKeyBundle } from '@xmtp/xmtp-js'
 // @ts-ignore
-import { sha256 } from '@xmtp/xmtp-js/dist/cjs/src/crypto/encryption'
+import { sha256 } from '@xmtp/xmtp-js'
 // @ts-ignore
-import { bytesToHex } from '@xmtp/xmtp-js/dist/cjs/src/crypto/utils'
+import { bytesToHex } from '@xmtp/xmtp-js'
 
 export function truncateHex(hex: string, shouldTruncate = true): string {
   if (!shouldTruncate) {


### PR DESCRIPTION
Adding `invite load [address] [batchSize] [batchCount]` command to emulate the scenario observed in https://github.com/xmtp/xmtp-node-go/issues/269. The command will repeatedly try to load the invites of a given wallet, in `batchCount` batches of `batchSize` parallel invitation loads. E.g. to run 100 batches of 50 queries each

```
npm start --silent -- invites load 0xb4743E780473b7bebD72B9F26D45c3e580DC32BC 50 100
```

Option `--page <numberOfEnvelopes>` invokes the paging API with the given number of envelopes per page.

Note that it is very easy to run into the WAF limits with this.

Also fixes `fill-conversations` to pace itself to respect the publish WAF limit (1000 publishes / 5 min). The chart shows a test run that hits the WAF limits first and then the batched run that keeps chugging along.

<img width="439" alt="Screenshot 2023-06-21 at 11 24 34" src="https://github.com/xmtp/xmtp-debug/assets/871693/2cb35a05-9130-4c1e-b097-ca901859d1c8">

Finally also fixes client creations to include `appVersion: xmtp-debug` so that we can identify traffic from the tool, and few other upgrades/fixes.