### PR TITLE
fix: bytesToHex is no longer exported

### DIFF
--- a/src/contacts.ts
+++ b/src/contacts.ts
@@ -1,4 +1,5 @@
 import { Client, SignedPublicKeyBundle, PublicKeyBundle } from '@xmtp/xmtp-js'
+import * as secp from '@noble/secp256k1'
 import {
   buildUserContactTopic,
   nsToDate,
@@ -7,7 +8,6 @@ import {
 // @ts-ignore
 import { decodeContactBundle } from '@xmtp/xmtp-js'
 // @ts-ignore
-import { bytesToHex } from '@xmtp/xmtp-js'
 import Long from 'long'
 import { fetcher } from '@xmtp/proto'
 import { toListOptions } from './utils'
@@ -94,10 +94,10 @@ async function list(contacts: Contact[], shouldTruncate = true) {
         : contact instanceof SignedPublicKeyBundle
         ? 'V2'
         : typeof contact
-    const identityKey = bytesToHex(
+    const identityKey = secp.utils.bytesToHex(
       contact.identityKey.secp256k1Uncompressed.bytes
     )
-    const preKey = bytesToHex(contact.preKey.secp256k1Uncompressed.bytes)
+    const preKey = secp.utils.bytesToHex(contact.preKey.secp256k1Uncompressed.bytes)
     rows.push({
       date: timestamp,
       type: type,
@@ -137,12 +137,12 @@ export function crosscheckContacts(
   const prodIdentityKeys = new Set<string>()
   for (const contact of devContacts) {
     devIdentityKeys.add(
-      bytesToHex(contact.contact.identityKey.secp256k1Uncompressed.bytes)
+      secp.utils.bytesToHex(contact.contact.identityKey.secp256k1Uncompressed.bytes)
     )
   }
   for (const contact of prodContacts) {
     prodIdentityKeys.add(
-      bytesToHex(contact.contact.identityKey.secp256k1Uncompressed.bytes)
+      secp.utils.bytesToHex(contact.contact.identityKey.secp256k1Uncompressed.bytes)
     )
   }
   const intersection = new Set(

--- a/src/verify_utils.ts
+++ b/src/verify_utils.ts
@@ -2,7 +2,7 @@ import { SignedPublicKeyBundle, PublicKeyBundle } from '@xmtp/xmtp-js'
 // @ts-ignore
 import { sha256 } from '@xmtp/xmtp-js'
 // @ts-ignore
-import { bytesToHex } from '@xmtp/xmtp-js'
+import * as secp from '@noble/secp256k1'
 
 export function truncateHex(hex: string, shouldTruncate = true): string {
   if (!shouldTruncate) {
@@ -105,12 +105,12 @@ export async function verifyPreKeyV1(keybundle: PublicKeyBundle) {
   // Check that the prekey is signed by the identity key
   let digest = await sha256(preKey.bytesToSign())
   let recoveredKey = preKey.signature!.getPublicKey(digest)
-  const identityKeyHex = bytesToHex(identityKey.secp256k1Uncompressed.bytes)
+  const identityKeyHex = secp.utils.bytesToHex(identityKey.secp256k1Uncompressed.bytes)
   if (!recoveredKey) {
     errors.push('prekey_sig_bad_recovers_to_null')
     return errors
   }
-  const recoveredKeyHex = bytesToHex(recoveredKey!.secp256k1Uncompressed.bytes)
+  const recoveredKeyHex = secp.utils.bytesToHex(recoveredKey!.secp256k1Uncompressed.bytes)
   if (identityKeyHex !== recoveredKeyHex) {
     errors.push('prekey_not_signed_by_idkey')
   }
@@ -222,12 +222,12 @@ export async function verifyPreKeyV2(keybundle: SignedPublicKeyBundle) {
   // Check that the prekey is signed by the identity key
   let digest = await sha256(preKey.bytesToSign())
   let recoveredKey = preKey.signature!.getPublicKey(digest)
-  const identityKeyHex = bytesToHex(identityKey.secp256k1Uncompressed.bytes)
+  const identityKeyHex = secp.utils.bytesToHex(identityKey.secp256k1Uncompressed.bytes)
   if (!recoveredKey) {
     errors.push('prekey_sig_bad_recovers_to_null')
     return errors
   }
-  const recoveredKeyHex = bytesToHex(recoveredKey!.secp256k1Uncompressed.bytes)
+  const recoveredKeyHex = secp.utils.bytesToHex(recoveredKey!.secp256k1Uncompressed.bytes)
   if (identityKeyHex !== recoveredKeyHex) {
     errors.push('prekey_not_signed_by_idkey')
   }


### PR DESCRIPTION
We no longer export the method `bytesToHex` from the jsSDK so get the method from `@noble/secp256k1'`