### PR TITLE
fix: project name error 

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Note that the options can also be set from environment variables prefixed with `
 
 ```sh
 $ export XMTP_ADDRESS=xmtp.eth
-$ export XMPT_ENV=production
+$ export XMTP_ENV=production
 $ npm start contacts list
 $ npm start intros list
 $ ...


### PR DESCRIPTION
I noticed that the project name was mistakenly written as **XMPT** instead of **XMTP** in the documentation. This PR corrects the typo to ensure accuracy and consistency throughout all project materials. Please review and merge to maintain the quality and reliability of our documentation.